### PR TITLE
Fix journalctl datasource example

### DIFF
--- a/docs/v1.X/docs/user_guide/data_sources/journalctl.md
+++ b/docs/v1.X/docs/user_guide/data_sources/journalctl.md
@@ -4,13 +4,13 @@ This module allows `{{v1X.crowdsec.name}}` to acquire logs from journalctl files
 
 ## Configuration Parameters
 
- - journalctl_filters: A list of journalctl filters. This is mandatory.
+ - journalctl_filter: A list of journalctl filters. This is mandatory.
  - source: Must be `journalctl`
 
 Basic configuration example:
 ```yaml
 source: journalctl
-journalctl_filters:
+journalctl_filter:
  - _SYSTEMD_UNIT=ssh.service
 ```
 


### PR DESCRIPTION
Fixing a small mistake in a configuration example.

This causes crowdsec to fail with the following error message:

> crowdsec init: Error while loading acquisition config : while loading acquisition configuration: data source type is empty ('source') in /etc/crowdsec/acquis.yaml
