### PR TITLE
Update journald.md

### DIFF
--- a/crowdsec-docs/docs/data_sources/journald.md
+++ b/crowdsec-docs/docs/data_sources/journald.md
@@ -12,13 +12,15 @@ To monitor SSH logs from journald:
 
 ```yaml
 source: journalctl
-journalctl_filters:
+journalctl_filter:
  - _SYSTEMD_UNIT=ssh.service
+labels:
+  type: journald
 ```
 
 ## Parameters
 
-### `journalctl_filters`
+### `journalctl_filter`
 
 A list of journalctl filters. This is mandatory.
 


### PR DESCRIPTION
journalctl_filters -> journalctl_filter
add type label

Based on these errors:

<details>
<summary>Journalctl_filters error</summary>

```console
crowdsec init: Error while loading acquisition config : while loading acquisition configuration: while configuring datasource of type journalctl from /etc/crowdsec/acquis.yaml: failed to configure datasource journalctl: Cannot parse JournalCtlSource configuration: yaml: unmarshal errors:\n  line 4: field journalctl_filters not found in type journalctlacquisition.JournalCtlConfiguration
```

</details>

<details>
<summary>Missing label error</summary>

crowdsec init: Error while loading acquisition config : while loading acquisition configuration: missing labels in /etc/crowdsec/acquis.yaml

</details>