### PR TITLE
Add link to docker hub docs for blocklist mirror

### DIFF
--- a/crowdsec-docs/docs/bouncers/blocklist-mirror.mdx
+++ b/crowdsec-docs/docs/bouncers/blocklist-mirror.mdx
@@ -53,6 +53,9 @@ sudo yum install crowdsec-blocklist-mirror
 
 </Tabs>
 
+## Installation using docker:
+
+Refer to docker [hub docs](https://hub.docker.com/r/crowdsecurity/blocklist-mirror)
 
 
 


### PR DESCRIPTION
Merge this after we have something at https://hub.docker.com/r/crowdsecurity/blocklist-mirror