### PR TITLE
Alert context doc

### DIFF
--- a/crowdsec-docs/docs/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/docs/configuration/crowdsec_configuration.md
@@ -35,6 +35,7 @@ config_paths:
 crowdsec_service:
   enable: true
   acquisition_path: /etc/crowdsec/acquis.yaml
+  console_context_path: /etc/crowdsec/console/context.yaml
   #acquisition_dir: /etc/crowdsec/acquis/
   parser_routines: 1
   buckets_routines: 1
@@ -198,6 +199,7 @@ crowdsec_service:
   enable: <true|false>  ## enable or disable crowdsec agent
   acquisition_path: "<acqusition_file_path>"
   acquisition_dir: "<acquisition_dir_path>"
+  console_context_path: <path_to_context_file>
   parser_routines: "<number_of_parser_routines>"
   buckets_routines: "<number_of_buckets_routines>"
   output_routines: "<number_of_output_routines>"
@@ -396,6 +398,7 @@ crowdsec_service:
   enable: <true|false>
   acquisition_path: "<acqusition_file_path>"
   acquisition_dir: "<acqusition_dir_path>"
+  console_context_path: <path_to_context_file>
   parser_routines: "<number_of_parser_routines>"
   buckets_routines: "<number_of_buckets_routines>"
   output_routines: "<number_of_output_routines>"
@@ -420,6 +423,11 @@ Number of dedicated goroutines for managing live buckets.
 > int
 
 Number of dedicated goroutines for pushing data to local api.
+
+#### `console_context_path`
+> string
+
+Path to the yaml file containing the context to send to the local API.
 
 #### `acquisition_path`
 > string

--- a/crowdsec-docs/docs/cscli/cscli.md
+++ b/crowdsec-docs/docs/cscli/cscli.md
@@ -15,7 +15,8 @@ It is meant to allow you to manage bans, parsers/scenarios/etc, api and generall
 
 ```
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
+      --color string    Output color: yes, no, auto. (default "auto")
       --debug           Set logging to debug.
       --info            Set logging to info.
       --warning         Set logging to warning.
@@ -41,9 +42,11 @@ It is meant to allow you to manage bans, parsers/scenarios/etc, api and generall
 * [cscli lapi](/cscli/cscli_lapi.md)	 - Manage interaction with Local API (LAPI)
 * [cscli machines](/cscli/cscli_machines.md)	 - Manage local API machines [requires local API]
 * [cscli metrics](/cscli/cscli_metrics.md)	 - Display crowdsec prometheus metrics.
+* [cscli notifications](/cscli/cscli_notifications.md)	 - Helper for notification plugin configuration
 * [cscli parsers](/cscli/cscli_parsers.md)	 - Install/Remove/Upgrade/Inspect parser(s) from hub
 * [cscli postoverflows](/cscli/cscli_postoverflows.md)	 - Install/Remove/Upgrade/Inspect postoverflow(s) from hub
 * [cscli scenarios](/cscli/cscli_scenarios.md)	 - Install/Remove/Upgrade/Inspect scenario(s) from hub
 * [cscli simulation](/cscli/cscli_simulation.md)	 - Manage simulation status of scenarios
+* [cscli support](/cscli/cscli_support.md)	 - Provide commands to help during support
 * [cscli version](/cscli/cscli_version.md)	 - Display version and exit.
 

--- a/crowdsec-docs/docs/cscli/cscli_alerts.md
+++ b/crowdsec-docs/docs/cscli/cscli_alerts.md
@@ -15,11 +15,12 @@ Manage alerts
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_alerts_delete.md
+++ b/crowdsec-docs/docs/cscli/cscli_alerts_delete.md
@@ -27,6 +27,7 @@ cscli alerts delete -s crowdsecurity/ssh-bf"
   -s, --scenario string   the scenario (ie. crowdsecurity/ssh-bf)
   -i, --ip string         Source ip (shorthand for --scope ip --value <IP>)
   -r, --range string      Range source ip (shorthand for --scope range --value <RANGE>)
+      --id string         alert ID
   -a, --all               delete all alerts
       --contained         query decisions contained by range
   -h, --help              help for delete
@@ -35,11 +36,12 @@ cscli alerts delete -s crowdsecurity/ssh-bf"
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_alerts_flush.md
+++ b/crowdsec-docs/docs/cscli/cscli_alerts_flush.md
@@ -28,11 +28,12 @@ cscli alerts flush --max-items 1000 --max-age 7d
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_alerts_inspect.md
+++ b/crowdsec-docs/docs/cscli/cscli_alerts_inspect.md
@@ -26,11 +26,12 @@ cscli alerts inspect 123
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_alerts_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_alerts_list.md
@@ -23,6 +23,7 @@ cscli alerts list --type ban
 ### Options
 
 ```
+  -a, --all               Include decisions from Central API
       --until string      restrict to alerts older than until (ie. 4h, 30d)
       --since string      restrict to alerts newer than since (ie. 4h, 30d)
   -i, --ip string         restrict to alerts from this source ip (shorthand for --scope ip --value <IP>)
@@ -32,7 +33,7 @@ cscli alerts list --type ban
       --scope string      restrict to alerts of this scope (ie. ip,range)
   -v, --value string      the value to match for in the specified scope
       --contained         query decisions contained by range
-  -m, --machine           print machines that sended alerts
+  -m, --machine           print machines that sent alerts
   -l, --limit int         limit size of alerts list table (0 to view all alerts) (default 50)
   -h, --help              help for list
 ```
@@ -40,11 +41,12 @@ cscli alerts list --type ban
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_bouncers.md
+++ b/crowdsec-docs/docs/cscli/cscli_bouncers.md
@@ -21,11 +21,12 @@ Note: This command requires database direct access, so is intended to be run on 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_bouncers_add.md
+++ b/crowdsec-docs/docs/cscli/cscli_bouncers_add.md
@@ -19,7 +19,7 @@ cscli bouncers add MyBouncerName [--length 16] [flags]
 ```
 cscli bouncers add MyBouncerName
 cscli bouncers add MyBouncerName -l 24
-cscli bouncers add MyBouncerName -k 2DHbHzWxtnpCnL46e4Hrv4qFLnPldpMe
+cscli bouncers add MyBouncerName -k bR96HTAfB5RGXSyv9YVNJ705KGkcesld
 ```
 
 ### Options
@@ -33,11 +33,12 @@ cscli bouncers add MyBouncerName -k 2DHbHzWxtnpCnL46e4Hrv4qFLnPldpMe
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_bouncers_delete.md
+++ b/crowdsec-docs/docs/cscli/cscli_bouncers_delete.md
@@ -19,11 +19,12 @@ cscli bouncers delete MyBouncerName [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_bouncers_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_bouncers_list.md
@@ -29,11 +29,12 @@ cscli bouncers list
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_capi.md
+++ b/crowdsec-docs/docs/cscli/cscli_capi.md
@@ -15,11 +15,12 @@ Manage interaction with Central API (CAPI)
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_capi_register.md
+++ b/crowdsec-docs/docs/cscli/cscli_capi_register.md
@@ -20,11 +20,12 @@ cscli capi register [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_capi_status.md
+++ b/crowdsec-docs/docs/cscli/cscli_capi_status.md
@@ -19,11 +19,12 @@ cscli capi status [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_collections.md
+++ b/crowdsec-docs/docs/cscli/cscli_collections.md
@@ -19,11 +19,12 @@ Install/Remove/Upgrade/Inspect collections from the CrowdSec Hub.
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```
@@ -33,7 +34,7 @@ Install/Remove/Upgrade/Inspect collections from the CrowdSec Hub.
 * [cscli](/cscli/cscli.md)	 - cscli allows you to manage crowdsec
 * [cscli collections inspect](/cscli/cscli_collections_inspect.md)	 - Inspect given collection
 * [cscli collections install](/cscli/cscli_collections_install.md)	 - Install given collection(s)
-* [cscli collections list](/cscli/cscli_collections_list.md)	 - List all collections or given one
+* [cscli collections list](/cscli/cscli_collections_list.md)	 - List all collections
 * [cscli collections remove](/cscli/cscli_collections_remove.md)	 - Remove given collection(s)
 * [cscli collections upgrade](/cscli/cscli_collections_upgrade.md)	 - Upgrade given collection(s)
 

--- a/crowdsec-docs/docs/cscli/cscli_collections_inspect.md
+++ b/crowdsec-docs/docs/cscli/cscli_collections_inspect.md
@@ -30,11 +30,12 @@ cscli collections inspect crowdsec/xxx crowdsec/xyz
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_collections_install.md
+++ b/crowdsec-docs/docs/cscli/cscli_collections_install.md
@@ -26,16 +26,18 @@ cscli collections install crowdsec/xxx crowdsec/xyz
   -d, --download-only   Only download packages, don't enable
       --force           Force install : Overwrite tainted and outdated files
   -h, --help            help for install
+      --ignore          Ignore errors when installing multiple collections
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_collections_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_collections_list.md
@@ -4,11 +4,11 @@ title: cscli collections list
 ---
 ## cscli collections list
 
-List all collections or given one
+List all collections
 
 ### Synopsis
 
-List all collections or given one
+List all collections
 
 ```
 cscli collections list collection [-a] [flags]
@@ -23,18 +23,19 @@ cscli collections list
 ### Options
 
 ```
-  -a, --all    List as well disabled items
+  -a, --all    List disabled items as well
   -h, --help   help for list
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_collections_remove.md
+++ b/crowdsec-docs/docs/cscli/cscli_collections_remove.md
@@ -32,11 +32,12 @@ cscli collections remove crowdsec/xxx crowdsec/xyz
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_collections_upgrade.md
+++ b/crowdsec-docs/docs/cscli/cscli_collections_upgrade.md
@@ -31,11 +31,12 @@ cscli collections upgrade crowdsec/xxx crowdsec/xyz
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_completion.md
+++ b/crowdsec-docs/docs/cscli/cscli_completion.md
@@ -46,10 +46,25 @@ To load completions:
   $ cscli completion zsh > "${fpath[1]}/_cscli"
 
   # You will need to start a new shell for this setup to take effect.
+
+### fish:
+```shell
+  $ cscli completion fish | source
+
+  # To load completions for each session, execute once:
+  $ cscli completion fish > ~/.config/fish/completions/cscli.fish
+```
+### PowerShell:
+```powershell
+  PS> cscli completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> cscli completion powershell > cscli.ps1
+  # and source this file from your PowerShell profile.
 ```
 
 ```
-cscli completion [bash|zsh]
+cscli completion [bash|zsh|powershell|fish]
 ```
 
 ### Options
@@ -61,11 +76,12 @@ cscli completion [bash|zsh]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_config.md
+++ b/crowdsec-docs/docs/cscli/cscli_config.md
@@ -15,11 +15,12 @@ Allows to view current config
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_config_backup.md
+++ b/crowdsec-docs/docs/cscli/cscli_config_backup.md
@@ -36,11 +36,12 @@ cscli config backup ./my-backup
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_config_restore.md
+++ b/crowdsec-docs/docs/cscli/cscli_config_restore.md
@@ -31,11 +31,12 @@ cscli config restore "directory" [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_config_show.md
+++ b/crowdsec-docs/docs/cscli/cscli_config_show.md
@@ -18,17 +18,18 @@ cscli config show [flags]
 
 ```
   -h, --help         help for show
-      --key string   Display only this value (config.API.Server.ListenURI
+      --key string   Display only this value (Config.API.Server.ListenURI)
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_console.md
+++ b/crowdsec-docs/docs/cscli/cscli_console.md
@@ -15,11 +15,12 @@ Manage interaction with Crowdsec console (https://app.crowdsec.net)
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```
@@ -27,5 +28,8 @@ Manage interaction with Crowdsec console (https://app.crowdsec.net)
 ### SEE ALSO
 
 * [cscli](/cscli/cscli.md)	 - cscli allows you to manage crowdsec
+* [cscli console disable](/cscli/cscli_console_disable.md)	 - Disable a feature flag
+* [cscli console enable](/cscli/cscli_console_enable.md)	 - Enable a feature flag
 * [cscli console enroll](/cscli/cscli_console_enroll.md)	 - Enroll this instance to https://app.crowdsec.net [requires local API]
+* [cscli console status](/cscli/cscli_console_status.md)	 - Shows status of one or all feature flags
 

--- a/crowdsec-docs/docs/cscli/cscli_console_disable.md
+++ b/crowdsec-docs/docs/cscli/cscli_console_disable.md
@@ -1,0 +1,47 @@
+---
+id: cscli_console_disable
+title: cscli console disable
+---
+## cscli console disable
+
+Disable a feature flag
+
+### Synopsis
+
+
+Disable given information push to the central API.
+
+```
+cscli console disable [feature-flag] [flags]
+```
+
+### Examples
+
+```
+sudo cscli console disable tainted
+```
+
+### Options
+
+```
+  -a, --all    Enable all feature flags
+  -h, --help   help for disable
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli console](/cscli/cscli_console.md)	 - Manage interaction with Crowdsec console (https://app.crowdsec.net)
+

--- a/crowdsec-docs/docs/cscli/cscli_console_enable.md
+++ b/crowdsec-docs/docs/cscli/cscli_console_enable.md
@@ -1,0 +1,47 @@
+---
+id: cscli_console_enable
+title: cscli console enable
+---
+## cscli console enable
+
+Enable a feature flag
+
+### Synopsis
+
+
+Enable given information push to the central API. Allows to empower the console
+
+```
+cscli console enable [feature-flag] [flags]
+```
+
+### Examples
+
+```
+sudo cscli console enable tainted
+```
+
+### Options
+
+```
+  -a, --all    Enable all feature flags
+  -h, --help   help for enable
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli console](/cscli/cscli_console.md)	 - Manage interaction with Crowdsec console (https://app.crowdsec.net)
+

--- a/crowdsec-docs/docs/cscli/cscli_console_enroll.md
+++ b/crowdsec-docs/docs/cscli/cscli_console_enroll.md
@@ -32,17 +32,19 @@ cscli console enroll YOUR-ENROLL-KEY
 ```
   -h, --help           help for enroll
   -n, --name string    Name to display in the console
+      --overwrite      Force enroll the instance
   -t, --tags strings   Tags to display in the console
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_console_status.md
+++ b/crowdsec-docs/docs/cscli/cscli_console_status.md
@@ -1,0 +1,49 @@
+---
+id: cscli_console_status
+title: cscli console status
+---
+## cscli console status
+
+Shows status of one or all feature flags
+
+```
+cscli console status [feature-flag] [flags]
+```
+
+### Examples
+
+```
+sudo cscli console status
++-------------+-----------+---------------------------------------------------+
+| Option Name | Activated | Description                                       |
++-------------+-----------+---------------------------------------------------+
+| custom      | ✅        | Send alerts from custom scenarios to the console  |
+| manual      | ❌        | Send manual decisions to the console              |
+| tainted     | ✅        | Send alerts from tainted scenarios to the console |
+| context     | ✅        | Send context with alerts to the console           |
++-------------+-----------+---------------------------------------------------+
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli console](/cscli/cscli_console.md)	 - Manage interaction with Crowdsec console (https://app.crowdsec.net)
+

--- a/crowdsec-docs/docs/cscli/cscli_dashboard.md
+++ b/crowdsec-docs/docs/cscli/cscli_dashboard.md
@@ -32,11 +32,12 @@ cscli dashboard remove
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```
@@ -46,6 +47,7 @@ cscli dashboard remove
 * [cscli](/cscli/cscli.md)	 - cscli allows you to manage crowdsec
 * [cscli dashboard remove](/cscli/cscli_dashboard_remove.md)	 - removes the metabase container.
 * [cscli dashboard setup](/cscli/cscli_dashboard_setup.md)	 - Setup a metabase container.
+* [cscli dashboard show-password](/cscli/cscli_dashboard_show-password.md)	 - displays password of metabase.
 * [cscli dashboard start](/cscli/cscli_dashboard_start.md)	 - Start the metabase container.
 * [cscli dashboard stop](/cscli/cscli_dashboard_stop.md)	 - Stops the metabase container.
 

--- a/crowdsec-docs/docs/cscli/cscli_dashboard_remove.md
+++ b/crowdsec-docs/docs/cscli/cscli_dashboard_remove.md
@@ -34,11 +34,12 @@ cscli dashboard remove --force
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_dashboard_setup.md
+++ b/crowdsec-docs/docs/cscli/cscli_dashboard_setup.md
@@ -39,11 +39,12 @@ cscli dashboard setup -l 0.0.0.0 -p 443 --password <password>
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_dashboard_show-password.md
+++ b/crowdsec-docs/docs/cscli/cscli_dashboard_show-password.md
@@ -1,0 +1,35 @@
+---
+id: cscli_dashboard_show-password
+title: cscli dashboard show-password
+---
+## cscli dashboard show-password
+
+displays password of metabase.
+
+```
+cscli dashboard show-password [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show-password
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli dashboard](/cscli/cscli_dashboard.md)	 - Manage your metabase dashboard container [requires local API]
+

--- a/crowdsec-docs/docs/cscli/cscli_dashboard_start.md
+++ b/crowdsec-docs/docs/cscli/cscli_dashboard_start.md
@@ -23,11 +23,12 @@ cscli dashboard start [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_dashboard_stop.md
+++ b/crowdsec-docs/docs/cscli/cscli_dashboard_stop.md
@@ -23,11 +23,12 @@ cscli dashboard stop [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_decisions.md
+++ b/crowdsec-docs/docs/cscli/cscli_decisions.md
@@ -8,7 +8,7 @@ Manage decisions
 
 ### Synopsis
 
-Add/List/Delete decisions from LAPI
+Add/List/Delete/Import decisions from LAPI
 
 ### Examples
 
@@ -25,11 +25,12 @@ cscli decisions [action] [filter]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```
@@ -39,5 +40,6 @@ cscli decisions [action] [filter]
 * [cscli](/cscli/cscli.md)	 - cscli allows you to manage crowdsec
 * [cscli decisions add](/cscli/cscli_decisions_add.md)	 - Add decision to LAPI
 * [cscli decisions delete](/cscli/cscli_decisions_delete.md)	 - Delete decisions
+* [cscli decisions import](/cscli/cscli_decisions_import.md)	 - Import decisions from json or csv file
 * [cscli decisions list](/cscli/cscli_decisions_list.md)	 - List decisions from LAPI
 

--- a/crowdsec-docs/docs/cscli/cscli_decisions_add.md
+++ b/crowdsec-docs/docs/cscli/cscli_decisions_add.md
@@ -36,11 +36,12 @@ cscli decisions add --scope username --value foobar
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_decisions_delete.md
+++ b/crowdsec-docs/docs/cscli/cscli_decisions_delete.md
@@ -15,7 +15,6 @@ cscli decisions delete [options] [flags]
 ```
 cscli decisions delete -r 1.2.3.0/24
 cscli decisions delete -i 1.2.3.4
-cscli decisions delete -s crowdsecurity/ssh-bf
 cscli decisions delete --id 42
 cscli decisions delete --type captcha
 
@@ -24,24 +23,26 @@ cscli decisions delete --type captcha
 ### Options
 
 ```
-  -i, --ip string      Source ip (shorthand for --scope ip --value <IP>)
-  -r, --range string   Range source ip (shorthand for --scope range --value <RANGE>)
-      --id string      decision id
-  -t, --type string    the decision type (ie. ban,captcha)
-  -v, --value string   the value to match for in the specified scope
-      --all            delete all decisions
-      --contained      query decisions contained by range
-  -h, --help           help for delete
+  -i, --ip string         Source ip (shorthand for --scope ip --value <IP>)
+  -r, --range string      Range source ip (shorthand for --scope range --value <RANGE>)
+  -t, --type string       the decision type (ie. ban,captcha)
+  -v, --value string      the value to match for in the specified scope
+  -s, --scenario string   the scenario name (ie. crowdsecurity/ssh-bf)
+      --id string         decision id
+      --all               delete all decisions
+      --contained         query decisions contained by range
+  -h, --help              help for delete
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_decisions_import.md
+++ b/crowdsec-docs/docs/cscli/cscli_decisions_import.md
@@ -44,11 +44,12 @@ decisions.json :
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_decisions_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_decisions_list.md
@@ -28,12 +28,14 @@ cscli decisions list -t ban
       --until string      restrict to alerts older than until (ie. 4h, 30d)
   -t, --type string       restrict to this decision type (ie. ban,captcha)
       --scope string      restrict to this scope (ie. ip,range,session)
+      --origin string     restrict to this origin (ie. lists,CAPI,cscli,cscli-import,crowdsec)
   -v, --value string      restrict to this value (ie. 1.2.3.4,userName)
   -s, --scenario string   restrict to this scenario (ie. crowdsecurity/ssh-bf)
   -i, --ip string         restrict to alerts from this source ip (shorthand for --scope ip --value <IP>)
   -r, --range string      restrict to alerts from this source range (shorthand for --scope range --value <RANGE>)
   -l, --limit int         number of alerts to get (use 0 to remove the limit) (default 100)
       --no-simu           exclude decisions in simulation mode
+  -m, --machine           print machines that triggered decisions
       --contained         query decisions contained by range
   -h, --help              help for list
 ```
@@ -41,11 +43,12 @@ cscli decisions list -t ban
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_explain.md
+++ b/crowdsec-docs/docs/cscli/cscli_explain.md
@@ -27,15 +27,14 @@ tail -n 5 myfile.log | cscli explain --type nginx -f -
 		
 ```
 
-Hint: if your are creating/collecting data on the fly (over a network, for example) and want to avoid temporary files, you can use `cscli explain --file /dev/fd/0` or `cscli explain -dsn "file://dev/fd/0"` to refer to standard input.
-
 ### Options
 
 ```
   -d, --dsn string    DSN to test
+      --failures      Only show failed lines
   -f, --file string   Log file to test
   -h, --help          help for explain
-  -l, --log string    Lgg line to test
+  -l, --log string    Log line to test
   -t, --type string   Type of the acquisition to test
   -v, --verbose       Display individual changes
 ```
@@ -43,11 +42,12 @@ Hint: if your are creating/collecting data on the fly (over a network, for examp
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hub.md
+++ b/crowdsec-docs/docs/cscli/cscli_hub.md
@@ -12,7 +12,7 @@ Manage Hub
 Hub management
 
 List/update parsers/scenarios/postoverflows/collections from [Crowdsec Hub](https://hub.crowdsec.net).
-Hub is managed by cscli, to get latest hub files from [Crowdsec Hub](https://hub.crowdsec.net), you need to update.
+The Hub is managed by cscli, to get the latest hub files from [Crowdsec Hub](https://hub.crowdsec.net), you need to update.
 		
 
 ### Examples
@@ -33,11 +33,12 @@ cscli hub update # Download list of available configurations from the hub
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hub_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_hub_list.md
@@ -13,7 +13,7 @@ cscli hub list [-a] [flags]
 ### Options
 
 ```
-  -a, --all    List as well disabled items
+  -a, --all    List disabled items as well
   -h, --help   help for list
 ```
 
@@ -21,11 +21,12 @@ cscli hub list [-a] [flags]
 
 ```
   -b, --branch string   Use given branch from hub
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hub_update.md
+++ b/crowdsec-docs/docs/cscli/cscli_hub_update.md
@@ -26,11 +26,12 @@ cscli hub update [flags]
 
 ```
   -b, --branch string   Use given branch from hub
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hub_upgrade.md
+++ b/crowdsec-docs/docs/cscli/cscli_hub_upgrade.md
@@ -27,11 +27,12 @@ cscli hub upgrade [flags]
 
 ```
   -b, --branch string   Use given branch from hub
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hubtest.md
+++ b/crowdsec-docs/docs/cscli/cscli_hubtest.md
@@ -8,9 +8,7 @@ Run functional tests on hub configurations
 
 ### Synopsis
 
-
-		Run functional tests on hub configurations (parsers, scenarios, collections...)
-		
+Run functional tests on hub configurations (parsers, scenarios, collections...)
 
 ### Options
 
@@ -24,11 +22,12 @@ Run functional tests on hub configurations
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hubtest_clean.md
+++ b/crowdsec-docs/docs/cscli/cscli_hubtest_clean.md
@@ -19,6 +19,7 @@ cscli hubtest clean [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string      Output color: yes, no, auto. (default "auto")
   -c, --config string     path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --crowdsec string   Path to crowdsec (default "crowdsec")
       --cscli string      Path to cscli (default "cscli")
@@ -26,7 +27,7 @@ cscli hubtest clean [flags]
       --error             Set logging to error.
       --hub string        Path to hub folder (default ".")
       --info              Set logging to info.
-  -o, --output string     Output format : human, json, raw.
+  -o, --output string     Output format: human, json, raw.
       --trace             Set logging to trace.
       --warning           Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hubtest_coverage.md
+++ b/crowdsec-docs/docs/cscli/cscli_hubtest_coverage.md
@@ -22,6 +22,7 @@ cscli hubtest coverage [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string      Output color: yes, no, auto. (default "auto")
   -c, --config string     path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --crowdsec string   Path to crowdsec (default "crowdsec")
       --cscli string      Path to cscli (default "cscli")
@@ -29,7 +30,7 @@ cscli hubtest coverage [flags]
       --error             Set logging to error.
       --hub string        Path to hub folder (default ".")
       --info              Set logging to info.
-  -o, --output string     Output format : human, json, raw.
+  -o, --output string     Output format: human, json, raw.
       --trace             Set logging to trace.
       --warning           Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hubtest_create.md
+++ b/crowdsec-docs/docs/cscli/cscli_hubtest_create.md
@@ -32,6 +32,7 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
 ### Options inherited from parent commands
 
 ```
+      --color string      Output color: yes, no, auto. (default "auto")
   -c, --config string     path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --crowdsec string   Path to crowdsec (default "crowdsec")
       --cscli string      Path to cscli (default "cscli")
@@ -39,7 +40,7 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
       --error             Set logging to error.
       --hub string        Path to hub folder (default ".")
       --info              Set logging to info.
-  -o, --output string     Output format : human, json, raw.
+  -o, --output string     Output format: human, json, raw.
       --trace             Set logging to trace.
       --warning           Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hubtest_eval.md
+++ b/crowdsec-docs/docs/cscli/cscli_hubtest_eval.md
@@ -20,6 +20,7 @@ cscli hubtest eval [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string      Output color: yes, no, auto. (default "auto")
   -c, --config string     path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --crowdsec string   Path to crowdsec (default "crowdsec")
       --cscli string      Path to cscli (default "cscli")
@@ -27,7 +28,7 @@ cscli hubtest eval [flags]
       --error             Set logging to error.
       --hub string        Path to hub folder (default ".")
       --info              Set logging to info.
-  -o, --output string     Output format : human, json, raw.
+  -o, --output string     Output format: human, json, raw.
       --trace             Set logging to trace.
       --warning           Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hubtest_explain.md
+++ b/crowdsec-docs/docs/cscli/cscli_hubtest_explain.md
@@ -19,6 +19,7 @@ cscli hubtest explain [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string      Output color: yes, no, auto. (default "auto")
   -c, --config string     path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --crowdsec string   Path to crowdsec (default "crowdsec")
       --cscli string      Path to cscli (default "cscli")
@@ -26,7 +27,7 @@ cscli hubtest explain [flags]
       --error             Set logging to error.
       --hub string        Path to hub folder (default ".")
       --info              Set logging to info.
-  -o, --output string     Output format : human, json, raw.
+  -o, --output string     Output format: human, json, raw.
       --trace             Set logging to trace.
       --warning           Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hubtest_info.md
+++ b/crowdsec-docs/docs/cscli/cscli_hubtest_info.md
@@ -19,6 +19,7 @@ cscli hubtest info [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string      Output color: yes, no, auto. (default "auto")
   -c, --config string     path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --crowdsec string   Path to crowdsec (default "crowdsec")
       --cscli string      Path to cscli (default "cscli")
@@ -26,7 +27,7 @@ cscli hubtest info [flags]
       --error             Set logging to error.
       --hub string        Path to hub folder (default ".")
       --info              Set logging to info.
-  -o, --output string     Output format : human, json, raw.
+  -o, --output string     Output format: human, json, raw.
       --trace             Set logging to trace.
       --warning           Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hubtest_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_hubtest_list.md
@@ -19,6 +19,7 @@ cscli hubtest list [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string      Output color: yes, no, auto. (default "auto")
   -c, --config string     path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --crowdsec string   Path to crowdsec (default "crowdsec")
       --cscli string      Path to cscli (default "cscli")
@@ -26,7 +27,7 @@ cscli hubtest list [flags]
       --error             Set logging to error.
       --hub string        Path to hub folder (default ".")
       --info              Set logging to info.
-  -o, --output string     Output format : human, json, raw.
+  -o, --output string     Output format: human, json, raw.
       --trace             Set logging to trace.
       --warning           Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_hubtest_run.md
+++ b/crowdsec-docs/docs/cscli/cscli_hubtest_run.md
@@ -22,6 +22,7 @@ cscli hubtest run [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string      Output color: yes, no, auto. (default "auto")
   -c, --config string     path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --crowdsec string   Path to crowdsec (default "crowdsec")
       --cscli string      Path to cscli (default "cscli")
@@ -29,7 +30,7 @@ cscli hubtest run [flags]
       --error             Set logging to error.
       --hub string        Path to hub folder (default ".")
       --info              Set logging to info.
-  -o, --output string     Output format : human, json, raw.
+  -o, --output string     Output format: human, json, raw.
       --trace             Set logging to trace.
       --warning           Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_lapi.md
+++ b/crowdsec-docs/docs/cscli/cscli_lapi.md
@@ -15,11 +15,12 @@ Manage interaction with Local API (LAPI)
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```
@@ -27,6 +28,7 @@ Manage interaction with Local API (LAPI)
 ### SEE ALSO
 
 * [cscli](/cscli/cscli.md)	 - cscli allows you to manage crowdsec
+* [cscli lapi context](/cscli/cscli_lapi_context.md)	 - Manage context to send with alerts
 * [cscli lapi register](/cscli/cscli_lapi_register.md)	 - Register a machine to Local API (LAPI)
 * [cscli lapi status](/cscli/cscli_lapi_status.md)	 - Check authentication to Local API (LAPI)
 

--- a/crowdsec-docs/docs/cscli/cscli_lapi_context.md
+++ b/crowdsec-docs/docs/cscli/cscli_lapi_context.md
@@ -1,0 +1,39 @@
+---
+id: cscli_lapi_context
+title: cscli lapi context
+---
+## cscli lapi context
+
+Manage context to send with alerts
+
+```
+cscli lapi context [feature-flag] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for context
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli lapi](/cscli/cscli_lapi.md)	 - Manage interaction with Local API (LAPI)
+* [cscli lapi context add](/cscli/cscli_lapi_context_add.md)	 - Add context to send with alerts. You must specify the output key with the expr value you want
+* [cscli lapi context delete](/cscli/cscli_lapi_context_delete.md)	 - Delete context to send with alerts
+* [cscli lapi context detect](/cscli/cscli_lapi_context_detect.md)	 - Detect available fields from the installed parsers
+* [cscli lapi context status](/cscli/cscli_lapi_context_status.md)	 - List context to send with alerts
+

--- a/crowdsec-docs/docs/cscli/cscli_lapi_context_add.md
+++ b/crowdsec-docs/docs/cscli/cscli_lapi_context_add.md
@@ -1,0 +1,45 @@
+---
+id: cscli_lapi_context_add
+title: cscli lapi context add
+---
+## cscli lapi context add
+
+Add context to send with alerts. You must specify the output key with the expr value you want
+
+```
+cscli lapi context add [flags]
+```
+
+### Examples
+
+```
+cscli lapi context add --key source_ip --value evt.Meta.source_ip
+cscli lapi context add --key file_source --value evt.Line.Src
+		
+```
+
+### Options
+
+```
+  -h, --help            help for add
+  -k, --key string      The key of the different values to send
+      --value strings   The expr fields to associate with the key
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli lapi context](/cscli/cscli_lapi_context.md)	 - Manage context to send with alerts
+

--- a/crowdsec-docs/docs/cscli/cscli_lapi_context_delete.md
+++ b/crowdsec-docs/docs/cscli/cscli_lapi_context_delete.md
@@ -1,0 +1,45 @@
+---
+id: cscli_lapi_context_delete
+title: cscli lapi context delete
+---
+## cscli lapi context delete
+
+Delete context to send with alerts
+
+```
+cscli lapi context delete [flags]
+```
+
+### Examples
+
+```
+cscli lapi context delete --key source_ip
+cscli lapi context delete --value evt.Line.Src
+		
+```
+
+### Options
+
+```
+  -h, --help            help for delete
+  -k, --key strings     The keys to delete
+      --value strings   The expr fields to delete
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli lapi context](/cscli/cscli_lapi_context.md)	 - Manage context to send with alerts
+

--- a/crowdsec-docs/docs/cscli/cscli_lapi_context_detect.md
+++ b/crowdsec-docs/docs/cscli/cscli_lapi_context_detect.md
@@ -1,0 +1,44 @@
+---
+id: cscli_lapi_context_detect
+title: cscli lapi context detect
+---
+## cscli lapi context detect
+
+Detect available fields from the installed parsers
+
+```
+cscli lapi context detect [flags]
+```
+
+### Examples
+
+```
+cscli lapi context detect --all
+cscli lapi context detect crowdsecurity/sshd-logs
+		
+```
+
+### Options
+
+```
+  -a, --all    Detect evt field for all installed parser
+  -h, --help   help for detect
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli lapi context](/cscli/cscli_lapi_context.md)	 - Manage context to send with alerts
+

--- a/crowdsec-docs/docs/cscli/cscli_lapi_context_status.md
+++ b/crowdsec-docs/docs/cscli/cscli_lapi_context_status.md
@@ -1,0 +1,35 @@
+---
+id: cscli_lapi_context_status
+title: cscli lapi context status
+---
+## cscli lapi context status
+
+List context to send with alerts
+
+```
+cscli lapi context status [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli lapi context](/cscli/cscli_lapi_context.md)	 - Manage context to send with alerts
+

--- a/crowdsec-docs/docs/cscli/cscli_lapi_register.md
+++ b/crowdsec-docs/docs/cscli/cscli_lapi_register.md
@@ -27,11 +27,12 @@ cscli lapi register [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_lapi_status.md
+++ b/crowdsec-docs/docs/cscli/cscli_lapi_status.md
@@ -19,11 +19,12 @@ cscli lapi status [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_machines.md
+++ b/crowdsec-docs/docs/cscli/cscli_machines.md
@@ -27,11 +27,12 @@ cscli machines [action]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_machines_add.md
+++ b/crowdsec-docs/docs/cscli/cscli_machines_add.md
@@ -28,7 +28,7 @@ cscli machines add MyTestMachine --password MyPassword
 
 ```
   -a, --auto              automatically generate password (and username if not provided)
-  -f, --file string       output file destination (defaults to /etc/crowdsec/local_api_credentials.yaml)
+  -f, --file string       output file destination (defaults to /etc/crowdsec/local_api_credentials.yaml
       --force             will force add the machine if it already exist
   -h, --help              help for add
   -i, --interactive       interfactive mode to enter the password
@@ -39,11 +39,12 @@ cscli machines add MyTestMachine --password MyPassword
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_machines_delete.md
+++ b/crowdsec-docs/docs/cscli/cscli_machines_delete.md
@@ -26,11 +26,12 @@ cscli machines delete "machine_name"
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_machines_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_machines_list.md
@@ -29,11 +29,12 @@ cscli machines list
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_machines_validate.md
+++ b/crowdsec-docs/docs/cscli/cscli_machines_validate.md
@@ -29,11 +29,12 @@ cscli machines validate "machine_name"
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_metrics.md
+++ b/crowdsec-docs/docs/cscli/cscli_metrics.md
@@ -18,17 +18,19 @@ cscli metrics [flags]
 
 ```
   -h, --help         help for metrics
+      --no-unit      Show the real number instead of formatted with units
   -u, --url string   Prometheus url (http://<ip>:<port>/metrics)
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_notifications.md
+++ b/crowdsec-docs/docs/cscli/cscli_notifications.md
@@ -1,0 +1,38 @@
+---
+id: cscli_notifications
+title: cscli notifications
+---
+## cscli notifications
+
+Helper for notification plugin configuration
+
+### Synopsis
+
+To list/inspect/test notification template
+
+### Options
+
+```
+  -h, --help   help for notifications
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli](/cscli/cscli.md)	 - cscli allows you to manage crowdsec
+* [cscli notifications inspect](/cscli/cscli_notifications_inspect.md)	 - Inspect active notifications plugin configuration
+* [cscli notifications list](/cscli/cscli_notifications_list.md)	 - List active notifications plugins
+* [cscli notifications reinject](/cscli/cscli_notifications_reinject.md)	 - reinject alert into notifications system
+

--- a/crowdsec-docs/docs/cscli/cscli_notifications_inspect.md
+++ b/crowdsec-docs/docs/cscli/cscli_notifications_inspect.md
@@ -1,0 +1,45 @@
+---
+id: cscli_notifications_inspect
+title: cscli notifications inspect
+---
+## cscli notifications inspect
+
+Inspect active notifications plugin configuration
+
+### Synopsis
+
+Inspect active notifications plugin and show configuration
+
+```
+cscli notifications inspect [flags]
+```
+
+### Examples
+
+```
+cscli notifications inspect <plugin_name>
+```
+
+### Options
+
+```
+  -h, --help   help for inspect
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli notifications](/cscli/cscli_notifications.md)	 - Helper for notification plugin configuration
+

--- a/crowdsec-docs/docs/cscli/cscli_notifications_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_notifications_list.md
@@ -1,0 +1,45 @@
+---
+id: cscli_notifications_list
+title: cscli notifications list
+---
+## cscli notifications list
+
+List active notifications plugins
+
+### Synopsis
+
+List active notifications plugins
+
+```
+cscli notifications list [flags]
+```
+
+### Examples
+
+```
+cscli notifications list
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli notifications](/cscli/cscli_notifications.md)	 - Helper for notification plugin configuration
+

--- a/crowdsec-docs/docs/cscli/cscli_notifications_reinject.md
+++ b/crowdsec-docs/docs/cscli/cscli_notifications_reinject.md
@@ -1,0 +1,51 @@
+---
+id: cscli_notifications_reinject
+title: cscli notifications reinject
+---
+## cscli notifications reinject
+
+reinject alert into notifications system
+
+### Synopsis
+
+Reinject alert into notifications system
+
+```
+cscli notifications reinject [flags]
+```
+
+### Examples
+
+```
+
+cscli notifications reinject <alert_id>
+cscli notifications reinject <alert_id> --remediation
+cscli notifications reinject <alert_id> -a '{"remediation": true,"scenario":"notification/test"}'
+
+```
+
+### Options
+
+```
+  -a, --alert string   JSON string used to override alert fields in the reinjected alert (see crowdsec/pkg/models/alert.go in the source tree for the full definition of the object)
+  -h, --help           help for reinject
+  -r, --remediation    Set Alert.Remediation to false in the reinjected alert (see your profile filter configuration)
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli notifications](/cscli/cscli_notifications.md)	 - Helper for notification plugin configuration
+

--- a/crowdsec-docs/docs/cscli/cscli_parsers.md
+++ b/crowdsec-docs/docs/cscli/cscli_parsers.md
@@ -26,11 +26,12 @@ cscli parsers remove crowdsecurity/sshd-logs
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_parsers_inspect.md
+++ b/crowdsec-docs/docs/cscli/cscli_parsers_inspect.md
@@ -30,11 +30,12 @@ cscli parsers inspect crowdsec/xxx
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_parsers_install.md
+++ b/crowdsec-docs/docs/cscli/cscli_parsers_install.md
@@ -26,16 +26,18 @@ cscli parsers install crowdsec/xxx crowdsec/xyz
   -d, --download-only   Only download packages, don't enable
       --force           Force install : Overwrite tainted and outdated files
   -h, --help            help for install
+      --ignore          Ignore errors when installing multiple parsers
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_parsers_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_parsers_list.md
@@ -24,18 +24,19 @@ cscli parser list crowdsecurity/xxx
 ### Options
 
 ```
-  -a, --all    List as well disabled items
+  -a, --all    List disabled items as well
   -h, --help   help for list
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_parsers_remove.md
+++ b/crowdsec-docs/docs/cscli/cscli_parsers_remove.md
@@ -32,11 +32,12 @@ cscli parsers remove crowdsec/xxx crowdsec/xyz
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_parsers_upgrade.md
+++ b/crowdsec-docs/docs/cscli/cscli_parsers_upgrade.md
@@ -31,11 +31,12 @@ cscli parsers upgrade crowdsec/xxx crowdsec/xyz
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_postoverflows.md
+++ b/crowdsec-docs/docs/cscli/cscli_postoverflows.md
@@ -25,11 +25,12 @@ cscli postoverflows install crowdsecurity/cdn-whitelist
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_postoverflows_inspect.md
+++ b/crowdsec-docs/docs/cscli/cscli_postoverflows_inspect.md
@@ -29,11 +29,12 @@ cscli postoverflows inspect crowdsec/xxx crowdsec/xyz
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_postoverflows_install.md
+++ b/crowdsec-docs/docs/cscli/cscli_postoverflows_install.md
@@ -26,16 +26,18 @@ cscli postoverflows install crowdsec/xxx crowdsec/xyz
   -d, --download-only   Only download packages, don't enable
       --force           Force install : Overwrite tainted and outdated files
   -h, --help            help for install
+      --ignore          Ignore errors when installing multiple postoverflows
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_postoverflows_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_postoverflows_list.md
@@ -24,18 +24,19 @@ cscli postoverflows list crowdsecurity/xxx
 ### Options
 
 ```
-  -a, --all    List as well disabled items
+  -a, --all    List disabled items as well
   -h, --help   help for list
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_postoverflows_remove.md
+++ b/crowdsec-docs/docs/cscli/cscli_postoverflows_remove.md
@@ -32,11 +32,12 @@ cscli postoverflows remove crowdsec/xxx crowdsec/xyz
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_postoverflows_upgrade.md
+++ b/crowdsec-docs/docs/cscli/cscli_postoverflows_upgrade.md
@@ -31,11 +31,12 @@ cscli postoverflows upgrade crowdsec/xxx crowdsec/xyz
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_scenarios.md
+++ b/crowdsec-docs/docs/cscli/cscli_scenarios.md
@@ -26,11 +26,12 @@ cscli scenarios remove crowdsecurity/ssh-bf
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_scenarios_inspect.md
+++ b/crowdsec-docs/docs/cscli/cscli_scenarios_inspect.md
@@ -30,11 +30,12 @@ cscli scenarios inspect crowdsec/xxx
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_scenarios_install.md
+++ b/crowdsec-docs/docs/cscli/cscli_scenarios_install.md
@@ -26,16 +26,18 @@ cscli scenarios install crowdsec/xxx crowdsec/xyz
   -d, --download-only   Only download packages, don't enable
       --force           Force install : Overwrite tainted and outdated files
   -h, --help            help for install
+      --ignore          Ignore errors when installing multiple scenarios
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_scenarios_list.md
+++ b/crowdsec-docs/docs/cscli/cscli_scenarios_list.md
@@ -24,18 +24,19 @@ cscli scenarios list crowdsecurity/xxx
 ### Options
 
 ```
-  -a, --all    List as well disabled items
+  -a, --all    List disabled items as well
   -h, --help   help for list
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_scenarios_remove.md
+++ b/crowdsec-docs/docs/cscli/cscli_scenarios_remove.md
@@ -32,11 +32,12 @@ cscli scenarios remove crowdsec/xxx crowdsec/xyz
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_scenarios_upgrade.md
+++ b/crowdsec-docs/docs/cscli/cscli_scenarios_upgrade.md
@@ -31,11 +31,12 @@ cscli scenarios upgrade crowdsec/xxx crowdsec/xyz
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_simulation.md
+++ b/crowdsec-docs/docs/cscli/cscli_simulation.md
@@ -23,11 +23,12 @@ cscli simulation disable crowdsecurity/ssh-bf
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_simulation_disable.md
+++ b/crowdsec-docs/docs/cscli/cscli_simulation_disable.md
@@ -26,11 +26,12 @@ cscli simulation disable
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_simulation_enable.md
+++ b/crowdsec-docs/docs/cscli/cscli_simulation_enable.md
@@ -26,11 +26,12 @@ cscli simulation enable
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_simulation_status.md
+++ b/crowdsec-docs/docs/cscli/cscli_simulation_status.md
@@ -25,11 +25,12 @@ cscli simulation status
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/cscli/cscli_support.md
+++ b/crowdsec-docs/docs/cscli/cscli_support.md
@@ -1,0 +1,32 @@
+---
+id: cscli_support
+title: cscli support
+---
+## cscli support
+
+Provide commands to help during support
+
+### Options
+
+```
+  -h, --help   help for support
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli](/cscli/cscli.md)	 - cscli allows you to manage crowdsec
+* [cscli support dump](/cscli/cscli_support_dump.md)	 - Dump all your configuration to a zip file for easier support
+

--- a/crowdsec-docs/docs/cscli/cscli_support_dump.md
+++ b/crowdsec-docs/docs/cscli/cscli_support_dump.md
@@ -1,0 +1,60 @@
+---
+id: cscli_support_dump
+title: cscli support dump
+---
+## cscli support dump
+
+Dump all your configuration to a zip file for easier support
+
+### Synopsis
+
+Dump the following informations:
+- Crowdsec version
+- OS version
+- Installed collections list
+- Installed parsers list
+- Installed scenarios list
+- Installed postoverflows list
+- Bouncers list
+- Machines list
+- CAPI status
+- LAPI status
+- Crowdsec config (sensitive information like username and password are redacted)
+- Crowdsec metrics
+
+```
+cscli support dump [flags]
+```
+
+### Examples
+
+```
+cscli support dump
+cscli support dump -f /tmp/crowdsec-support.zip
+
+```
+
+### Options
+
+```
+  -h, --help             help for dump
+  -f, --outFile string   File to dump the information to
+```
+
+### Options inherited from parent commands
+
+```
+      --color string    Output color: yes, no, auto. (default "auto")
+  -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
+      --debug           Set logging to debug.
+      --error           Set logging to error.
+      --info            Set logging to info.
+  -o, --output string   Output format: human, json, raw.
+      --trace           Set logging to trace.
+      --warning         Set logging to warning.
+```
+
+### SEE ALSO
+
+* [cscli support](/cscli/cscli_support.md)	 - Provide commands to help during support
+

--- a/crowdsec-docs/docs/cscli/cscli_version.md
+++ b/crowdsec-docs/docs/cscli/cscli_version.md
@@ -19,11 +19,12 @@ cscli version [flags]
 ### Options inherited from parent commands
 
 ```
+      --color string    Output color: yes, no, auto. (default "auto")
   -c, --config string   path to crowdsec config file (default "/etc/crowdsec/config.yaml")
       --debug           Set logging to debug.
       --error           Set logging to error.
       --info            Set logging to info.
-  -o, --output string   Output format : human, json, raw.
+  -o, --output string   Output format: human, json, raw.
       --trace           Set logging to trace.
       --warning         Set logging to warning.
 ```

--- a/crowdsec-docs/docs/user_guides/alert_context.md
+++ b/crowdsec-docs/docs/user_guides/alert_context.md
@@ -1,0 +1,145 @@
+---
+id: alert_context
+title: Contextualize Alerts
+sidebar_position: 10
+---
+
+
+
+# Alert Contextualization
+
+
+While CrowdSec doesn't store any logs after processing it, it can be useful to get some context about why an alert has been triggered (source machine, targeted FQDN ...).
+
+It is possible to enable this feature in your CrowdSec agent configuration. You can choose which fields from a parsed log you want to be added in the context of the alert.
+
+
+## Add context to alerts
+
+You can choose the fields that you want to add to the context of your alerts with `cscli`:
+
+```bash
+sudo cscli lapi context add --key target_fqdn --value evt.Meta.target_fqdn
+sudo cscli lapi context add --key user_agent --value evt.Parsed.http_user_agent
+```
+
+
+## Vizualise alert context
+
+The alert context will be display when inspecting an alert:
+
+```bash
+$ sudo cscli alerts inspect 7
+
+################################################################################################
+
+ - ID         : 7
+ - Date       : 2022-12-12T18:46:44Z
+ - Machine    : c620f52cedf9432e969f26afee12d651
+ - Simulation : false
+ - Reason     : crowdsecurity/http-bad-user-agent
+ - Events Count : 2
+ - Scope:Value: Ip:127.0.0.1
+ - Country    : 
+ - AS         : 
+ - Begin      : 2022-12-12 18:46:43.339960525 +0000 UTC
+ - End        : 2022-12-12 18:46:43.341210351 +0000 UTC
+
+ - Active Decisions  :
+╭───────┬──────────────┬────────┬────────────────────┬──────────────────────╮
+│  ID   │ scope:value  │ action │     expiration     │      created_at      │
+├───────┼──────────────┼────────┼────────────────────┼──────────────────────┤
+│ 15006 │ Ip:127.0.0.1 │ ban    │ 3h59m50.949157024s │ 2022-12-12T18:46:44Z │
+╰───────┴──────────────┴────────┴────────────────────┴──────────────────────╯
+
+ - Context  :
+╭─────────────┬──────────────────────────────────────────────────────────────╮
+│     Key     │                            Value                             │
+├─────────────┼──────────────────────────────────────────────────────────────┤
+│ target_fqdn │ www.crowdsec-test.net                                        │
+│ target_fqdn │ www.crowdsec-test-1.net                                      │
+│ user_agent  │ Mozilla/5.00 (Nikto/2.1.5) (Evasions:None) (Test:Port Check) │
+│ user_agent  │ Mozilla/5.00 (Nikto/2.1.5) (Evasions:None) (Test:getinfo)    │
+╰─────────────┴──────────────────────────────────────────────────────────────╯
+```
+
+And we can see that the `target_fqdn` and the `user_agent` are now displayed in the context of the alert.
+
+
+## Delete a context
+
+It is possible to delete a context by its key:
+```bash
+sudo cscli lapi context  delete --key user_agent       
+INFO[12-12-2022 07:49:01 PM] key 'user_agent' has been removed            
+INFO[12-12-2022 07:49:01 PM] /etc/crowdsec/console/context.yaml file saved
+```
+
+
+Or it is possible to delete a context by its value:
+
+```bash
+sudo cscli lapi context delete --value evt.Meta.target_fqdn
+INFO[12-12-2022 07:48:38 PM] value 'evt.Meta.target_fqdn' has been removed from key 'target_fqdn' 
+INFO[12-12-2022 07:48:38 PM] /etc/crowdsec/console/context.yaml file saved 
+```
+
+## Detect possible values for context
+
+
+It is possible to detect all the possible field that a given parser can output (or all the parser with `--all` flag):
+
+```bash
+$ sudo cscli lapi context detect crowdsecurity/nginx-logs
+Acquisition :
+
+  - evt.Line.Module
+  - evt.Line.Raw
+  - evt.Line.Src
+
+crowdsecurity/nginx-logs :
+
+  - evt.Meta.http_path
+  - evt.Meta.http_status
+  - evt.Meta.http_user_agent
+  - evt.Meta.http_verb
+  - evt.Meta.log_type
+  - evt.Meta.service
+  - evt.Meta.source_ip
+  - evt.Meta.target_fqdn
+  - evt.Parsed.body_bytes_sent
+  - evt.Parsed.cid
+  - evt.Parsed.http_referer
+  - evt.Parsed.http_user_agent
+  - evt.Parsed.http_version
+  - evt.Parsed.loglevel
+  - evt.Parsed.message
+  - evt.Parsed.pid
+  - evt.Parsed.proxy_alternative_upstream_name
+  - evt.Parsed.proxy_upstream_name
+  - evt.Parsed.remote_addr
+  - evt.Parsed.remote_user
+  - evt.Parsed.request
+  - evt.Parsed.request_length
+  - evt.Parsed.request_time
+  - evt.Parsed.status
+  - evt.Parsed.target_fqdn
+  - evt.Parsed.tid
+  - evt.Parsed.time
+  - evt.Parsed.time_local
+  - evt.Parsed.verb
+  - evt.StrTime
+
+```
+
+## Send alert context to CrowdSec Console
+
+
+To send the context with the alert to the CrowdSec Console, you need to enable the feature on the CrowdSec Local API server:
+
+```bash
+$ sudo cscli console enable context       
+INFO[12-12-2022 08:21:29 PM] context set to true                          
+INFO[12-12-2022 08:21:29 PM] [context] have been enabled                  
+INFO[12-12-2022 08:21:29 PM] Run 'sudo systemctl reload crowdsec' for the new configuration to be effective. 
+```

--- a/crowdsec-docs/docs/user_guides/alert_context.md
+++ b/crowdsec-docs/docs/user_guides/alert_context.md
@@ -87,7 +87,7 @@ INFO[12-12-2022 07:48:38 PM] /etc/crowdsec/console/context.yaml file saved
 ## Detect possible values for context
 
 
-It is possible to detect all the possible field that a given parser can output (or all the parser with `--all` flag):
+It is possible to detect all the possible fields that a given parser can output (or all the installed parsers with `--all` flag):
 
 ```bash
 $ sudo cscli lapi context detect crowdsecurity/nginx-logs

--- a/crowdsec-docs/sidebars.js
+++ b/crowdsec-docs/sidebars.js
@@ -170,12 +170,12 @@ module.exports = {
         {
           type: "category",
           label: "cscli console",
-          items: ["cscli/cscli_console","cscli/cscli_console_enroll"]
+          items: ["cscli/cscli_console","cscli/cscli_console_enroll", "cscli/cscli_console_disable", "cscli/cscli_console_enable", "cscli/cscli_console_status"]
         },
         {
           type: "category",
           label: "cscli dashboard",
-          items: ["cscli/cscli_dashboard","cscli/cscli_dashboard_remove","cscli/cscli_dashboard_setup","cscli/cscli_dashboard_start","cscli/cscli_dashboard_stop"]
+          items: ["cscli/cscli_dashboard","cscli/cscli_dashboard_remove","cscli/cscli_dashboard_setup","cscli/cscli_dashboard_start","cscli/cscli_dashboard_stop", "cscli/cscli_dashboard_show-password"]
         },
         {
           type: "category",
@@ -195,7 +195,7 @@ module.exports = {
         {
           type: "category",
           label: "cscli lapi",
-          items: ["cscli/cscli_lapi","cscli/cscli_lapi_register","cscli/cscli_lapi_status"]
+          items: ["cscli/cscli_lapi","cscli/cscli_lapi_register","cscli/cscli_lapi_status", "cscli/cscli_lapi_context", "cscli/cscli_lapi_context_add", "cscli/cscli_lapi_context_delete", "cscli/cscli_lapi_context_detect", "cscli/cscli_lapi_context_status"]
         },
         {
           type: "category",
@@ -206,6 +206,11 @@ module.exports = {
           type: "category",
           label: "cscli metrics",
           items: ["cscli/cscli_metrics"]
+        },
+        {
+          type: "category",
+          label: "cscli notification",
+          items: ["cscli/cscli_notifications", "cscli/cscli_notifications_inspect", "cscli/cscli_notifications_list", "cscli/cscli_notifications_reinject"]
         },
         {
           type: "category",
@@ -231,6 +236,11 @@ module.exports = {
           type: "category",
           label: "cscli simulation",
           items: ["cscli/cscli_simulation","cscli/cscli_simulation_disable","cscli/cscli_simulation_enable","cscli/cscli_simulation_status"]
+        },
+        {
+          type: "category",
+          label: "cscli support",
+          items: ["cscli/cscli_support","cscli/cscli_support_dump"]
         },
         {
           type: "category",

--- a/crowdsec-docs/sidebars.js
+++ b/crowdsec-docs/sidebars.js
@@ -50,7 +50,7 @@ module.exports = {
     {
       type: 'category',
       label: 'User Guides',
-      items: ["user_guides/hub_mgmt", "user_guides/decisions_mgmt", "user_guides/bouncers_configuration", "user_guides/machines_mgmt", "user_guides/lapi_mgmt","user_guides/building", "user_guides/replay_mode", "user_guides/cscli_explain", "user_guides/cscli_macos", "user_guides/multiserver_setup", "user_guides/consuming_fastly_logs"]
+      items: ["user_guides/hub_mgmt", "user_guides/decisions_mgmt", "user_guides/bouncers_configuration", "user_guides/machines_mgmt", "user_guides/lapi_mgmt","user_guides/building", "user_guides/replay_mode", "user_guides/cscli_explain", "user_guides/cscli_macos", "user_guides/multiserver_setup", "user_guides/consuming_fastly_logs", "user_guides/alert_context"]
     },
     {
       type: 'category',


### PR DESCRIPTION
- Add alert context documentation ([this](https://github.com/crowdsecurity/crowdsec-docs/commit/e291ba00b8c9914f8b8e7527e99ff410fdd1838c) commit)
- Add cscli command for `lapi context` and update cscli documentation (with new global `-o`  and `--color` flags and missing command documentation: `cscli notification`, `cscli dump`, `cscli dashboard show-password`, `cscli console (disable|enable|status)` ([this](https://github.com/crowdsecurity/crowdsec-docs/commit/50e53ab30723e28ec1d1b165f716d591eea15858) commit)