### PR TITLE
Update postgresql instructions for Postgresql 15

### DIFF
--- a/crowdsec-docs/docs/local_api/database.md
+++ b/crowdsec-docs/docs/local_api/database.md
@@ -45,6 +45,7 @@ Connect to your `PostgreSQL` server and run the following commands:
 ```
 postgres=# CREATE DATABASE crowdsec;
 postgres=# CREATE USER crowdsec WITH PASSWORD '<password>';
+postgres=# ALTER SCHEMA public owner to crowdsec;
 postgres=# GRANT ALL PRIVILEGES ON DATABASE crowdsec TO crowdsec;
 ```
 


### PR DESCRIPTION
Postgres 15 does not allow creation of tables in `public` (default)  schema without  super-user access rights. `crowdsec` has to be made the owner of the public schema first. See https://stackoverflow.com/questions/74110708/postgres-15-permission-denied-for-schema-public. 

Public schemas are also in version 14 and 13, but the required access rights have been changed in 15.0.  