### PR TITLE
Update prometheus.md to include help text on scraping

### DIFF
--- a/crowdsec-docs/docs/observability/prometheus.md
+++ b/crowdsec-docs/docs/observability/prometheus.md
@@ -4,7 +4,7 @@ title: Prometheus
 sidebar_position: 4
 ---
 
-CrowdSec can expose a [prometheus](https://github.com/prometheus/client_golang) endpoint for collection (on `http://127.0.0.1:6060/metrics` by default).
+CrowdSec can expose a [prometheus](https://github.com/prometheus/client_golang) endpoint for collection (on `http://127.0.0.1:6060/metrics` by default). You can edit the listen_addr in config.yaml to allow an external Prometheus to scrape the metrics.
 
 The goal of this endpoint, besides the usual resources consumption monitoring, aims at offering a view of CrowdSec "applicative" behavior :
 

--- a/crowdsec-docs/docs/observability/prometheus.md
+++ b/crowdsec-docs/docs/observability/prometheus.md
@@ -4,7 +4,7 @@ title: Prometheus
 sidebar_position: 4
 ---
 
-CrowdSec can expose a [prometheus](https://github.com/prometheus/client_golang) endpoint for collection (on `http://127.0.0.1:6060/metrics` by default). You can edit the listen_addr in config.yaml to allow an external Prometheus to scrape the metrics.
+CrowdSec can expose a [prometheus](https://github.com/prometheus/client_golang) endpoint for collection (on `http://127.0.0.1:6060/metrics` by default). You can edit the listen_addr in [config.yaml](/configuration/crowdsec_configuration.md#prometheus) to allow an external Prometheus to scrape the metrics.
 
 The goal of this endpoint, besides the usual resources consumption monitoring, aims at offering a view of CrowdSec "applicative" behavior :
 

--- a/crowdsec-docs/versioned_docs/version-v1.5.0/observability/prometheus.md
+++ b/crowdsec-docs/versioned_docs/version-v1.5.0/observability/prometheus.md
@@ -4,7 +4,7 @@ title: Prometheus
 sidebar_position: 4
 ---
 
-CrowdSec can expose a [prometheus](https://github.com/prometheus/client_golang) endpoint for collection (on `http://127.0.0.1:6060/metrics` by default).
+CrowdSec can expose a [prometheus](https://github.com/prometheus/client_golang) endpoint for collection (on `http://127.0.0.1:6060/metrics` by default). You can edit the listen_addr in /etc/crowdsec/config.yaml to allow an external Prometheus to scrape the metrics.
 
 The goal of this endpoint, besides the usual resources consumption monitoring, aims at offering a view of CrowdSec "applicative" behavior :
 

--- a/crowdsec-docs/versioned_docs/version-v1.5.0/observability/prometheus.md
+++ b/crowdsec-docs/versioned_docs/version-v1.5.0/observability/prometheus.md
@@ -4,7 +4,7 @@ title: Prometheus
 sidebar_position: 4
 ---
 
-CrowdSec can expose a [prometheus](https://github.com/prometheus/client_golang) endpoint for collection (on `http://127.0.0.1:6060/metrics` by default). You can edit the listen_addr in config.yaml to allow an external Prometheus to scrape the metrics.
+CrowdSec can expose a [prometheus](https://github.com/prometheus/client_golang) endpoint for collection (on `http://127.0.0.1:6060/metrics` by default). You can edit the listen_addr in [config.yaml](/configuration/crowdsec_configuration.md#prometheus) to allow an external Prometheus to scrape the metrics.
 
 The goal of this endpoint, besides the usual resources consumption monitoring, aims at offering a view of CrowdSec "applicative" behavior :
 

--- a/crowdsec-docs/versioned_docs/version-v1.5.0/observability/prometheus.md
+++ b/crowdsec-docs/versioned_docs/version-v1.5.0/observability/prometheus.md
@@ -4,7 +4,7 @@ title: Prometheus
 sidebar_position: 4
 ---
 
-CrowdSec can expose a [prometheus](https://github.com/prometheus/client_golang) endpoint for collection (on `http://127.0.0.1:6060/metrics` by default). You can edit the listen_addr in /etc/crowdsec/config.yaml to allow an external Prometheus to scrape the metrics.
+CrowdSec can expose a [prometheus](https://github.com/prometheus/client_golang) endpoint for collection (on `http://127.0.0.1:6060/metrics` by default). You can edit the listen_addr in config.yaml to allow an external Prometheus to scrape the metrics.
 
 The goal of this endpoint, besides the usual resources consumption monitoring, aims at offering a view of CrowdSec "applicative" behavior :
 


### PR DESCRIPTION
Added some help text to let the user know where they can edit the listen_addr to allow an external Prometheus to scrape metrics.

If the added text would be better placed somewhere else please provide feedback.