### PR TITLE
Fix typo in docs/whitelist/create (fixes #441)

### DIFF
--- a/crowdsec-docs/versioned_docs/version-v1.0/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.0/whitelist/create.md
@@ -119,7 +119,7 @@ A good example is the [crowdsecurity/whitelist-good-actors](https://hub.crowdsec
 But let's craft ours based on our previous example !
 First of all, install the [crowdsecurity/rdns postoverflow](https://hub.crowdsec.net/author/crowdsecurity/configurations/rdns) : it will be in charge of enriching overflows with reverse dns information of the offending IP.
 
-Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelists/mywhitelists.yaml` :
+Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelist/mywhitelists.yaml` :
 
 ```yaml
 name: me/my_cool_whitelist

--- a/crowdsec-docs/versioned_docs/version-v1.1/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.1/whitelist/create.md
@@ -119,7 +119,7 @@ A good example is the [crowdsecurity/whitelist-good-actors](https://hub.crowdsec
 But let's craft ours based on our previous example !
 First of all, install the [crowdsecurity/rdns postoverflow](https://hub.crowdsec.net/author/crowdsecurity/configurations/rdns) : it will be in charge of enriching overflows with reverse dns information of the offending IP.
 
-Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelists/mywhitelists.yaml` :
+Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelist/mywhitelists.yaml` :
 
 ```yaml
 name: me/my_cool_whitelist

--- a/crowdsec-docs/versioned_docs/version-v1.2.2/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.2.2/whitelist/create.md
@@ -130,7 +130,7 @@ A good example is the [crowdsecurity/whitelist-good-actors](https://hub.crowdsec
 But let's craft ours based on our previous example !
 First of all, install the [crowdsecurity/rdns postoverflow](https://hub.crowdsec.net/author/crowdsecurity/configurations/rdns) : it will be in charge of enriching overflows with reverse dns information of the offending IP.
 
-Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelists/mywhitelists.yaml` :
+Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelist/mywhitelists.yaml` :
 
 ```yaml
 name: me/my_cool_whitelist

--- a/crowdsec-docs/versioned_docs/version-v1.2/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.2/whitelist/create.md
@@ -130,7 +130,7 @@ A good example is the [crowdsecurity/whitelist-good-actors](https://hub.crowdsec
 But let's craft ours based on our previous example !
 First of all, install the [crowdsecurity/rdns postoverflow](https://hub.crowdsec.net/author/crowdsecurity/configurations/rdns) : it will be in charge of enriching overflows with reverse dns information of the offending IP.
 
-Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelists/mywhitelists.yaml` :
+Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelist/mywhitelists.yaml` :
 
 ```yaml
 name: me/my_cool_whitelist

--- a/crowdsec-docs/versioned_docs/version-v1.3.0/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.3.0/whitelist/create.md
@@ -130,7 +130,7 @@ A good example is the [crowdsecurity/whitelist-good-actors](https://hub.crowdsec
 But let's craft ours based on our previous example !
 First of all, install the [crowdsecurity/rdns postoverflow](https://hub.crowdsec.net/author/crowdsecurity/configurations/rdns) : it will be in charge of enriching overflows with reverse dns information of the offending IP.
 
-Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelists/mywhitelists.yaml` :
+Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelist/mywhitelists.yaml` :
 
 ```yaml
 name: me/my_cool_whitelist

--- a/crowdsec-docs/versioned_docs/version-v1.3.4/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.3.4/whitelist/create.md
@@ -130,7 +130,7 @@ A good example is the [crowdsecurity/whitelist-good-actors](https://hub.crowdsec
 But let's craft ours based on our previous example !
 First of all, install the [crowdsecurity/rdns postoverflow](https://hub.crowdsec.net/author/crowdsecurity/configurations/rdns) : it will be in charge of enriching overflows with reverse dns information of the offending IP address.
 
-Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelists/mywhitelists.yaml` :
+Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelist/mywhitelists.yaml` :
 
 ```yaml
 name: me/my_cool_whitelist

--- a/crowdsec-docs/versioned_docs/version-v1.4.0/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.4.0/whitelist/create.md
@@ -130,7 +130,7 @@ A good example is the [crowdsecurity/whitelist-good-actors](https://hub.crowdsec
 But let's craft ours based on our previous example !
 First of all, install the [crowdsecurity/rdns postoverflow](https://hub.crowdsec.net/author/crowdsecurity/configurations/rdns) : it will be in charge of enriching overflows with reverse dns information of the offending IP address.
 
-Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelists/mywhitelists.yaml` :
+Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelist/mywhitelists.yaml` :
 
 ```yaml
 name: me/my_cool_whitelist

--- a/crowdsec-docs/versioned_docs/version-v1.5.0/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.5.0/whitelist/create.md
@@ -130,7 +130,7 @@ A good example is the [crowdsecurity/whitelist-good-actors](https://hub.crowdsec
 But let's craft ours based on our previous example !
 First of all, install the [crowdsecurity/rdns postoverflow](https://hub.crowdsec.net/author/crowdsecurity/configurations/rdns) : it will be in charge of enriching overflows with reverse dns information of the offending IP address.
 
-Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelists/mywhitelists.yaml` :
+Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelist/mywhitelists.yaml` :
 
 ```yaml
 name: me/my_cool_whitelist
@@ -164,7 +164,7 @@ This time, we can see that logs are being produced when the event is discarded.
 
 You might want to whitelist a fully qualified domain name (FQDN eg foo.com), in that case you need to follow this below
 
-Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelists/FQDN-whitelists.yaml` (create the folders if not exist):
+Let's put the following file in `/etc/crowdsec/postoverflows/s01-whitelist/FQDN-whitelists.yaml` (create the folders if not exist):
 ```yaml
 name: me/FQDN-whitlists
 description: "Whitelist postoverflows from FQDN"


### PR DESCRIPTION
Correct path for postoverflow whitelist:
`/etc/crowdsec/postoverflows/s01-whitelists/...` -> `/etc/crowdsec/postoverflows/s01-whitelist/...`