### PR TITLE
feat: allow searching in arrays in tables

### DIFF
--- a/crowdsec-docs/docs/cti_api/taxonomy/scenarios.mdx
+++ b/crowdsec-docs/docs/cti_api/taxonomy/scenarios.mdx
@@ -28,10 +28,14 @@ export const columns = [
         header: "Mitre ATT&CK",
         accessorKey: "mitre_attacks",
         size: 180,
-        Cell: ({ cell}) => {
+        Cell: ({ cell }) => {
             const values = cell.getValue();
+            if (values == undefined) {
+                return values;
+            }
             return (
-                values.map((item, i) => {
+                // values is a CSV to allow global search, so we need to split it again for proper rendering
+                values.split('\n').map((item, i) => {
                     var v = item.split(":");
                     var technique = v.slice(-1)[0]
                     return (
@@ -53,7 +57,7 @@ export const columns = [
                 return values;
             }
             return (
-                values.map((item, i) => {
+                values.split('\n').map((item, i) => {
                     return (
                         <div>
                             <a key={item} href={'https://cve.mitre.org/cgi-bin/cvename.cgi?name='+item}>{item}</a>

--- a/crowdsec-docs/src/components/tableRender.js
+++ b/crowdsec-docs/src/components/tableRender.js
@@ -31,21 +31,30 @@ const TableRender = ({ columns, url }) => {
         fetch(url)
             .then((res) => res.json())
             .then((data) => {
-                const newData = [];
+                const updatedData = [];
                 const names = [];
 
                 Object.keys(data).map((key, i) => {
                     // filter duplicate names
-                    const name = data[key]["name"];
+                    const item = data[key];
+                    const name = item["name"];
 
                     if (names.includes(name)) {
                         return
                     }
 
                     names.push(name)
-                    newData.push(data[key]);
-                })
-                setJsonContent(newData)
+                    updatedData.push({
+                      ...item,
+                      // flattening list of strings into CSV strings allow global filtering on them
+                      // /!\ it requires special handling in the rendering side (see crowdsec-docs/docs/cti_api/taxonomy) /!\
+                      ...item.behaviors ? { behaviors: item.behaviors.join('\n') } : {},
+                      ...item.mitre_attacks ? { mitre_attacks: item.mitre_attacks.join('\n') } : {},
+                      ...item.cves ? { cves: item.cves.join('\n') } : {},
+                    });
+                });
+
+                setJsonContent(updatedData);
             })
     // execute this fetch only once (on mount)
     }, []);


### PR DESCRIPTION
# Context

In some tables we have **array values**, which seem not compatible with the global filtering of `material-react-table`.

# Content

I did a kind of hack to allow searching in specific array values:
- transform array values into CSV strings in the `TableRender` component, making the global filter work on these values
- transform CSV strings into arrays before using `.map` on them to render each of them in `<p>` tags