### PR TITLE
[Console] links to shortcut enrollment screen

### DIFF
--- a/crowdsec-docs/docs/getting_started/getting_started.md
+++ b/crowdsec-docs/docs/getting_started/getting_started.md
@@ -75,6 +75,6 @@ If you are uncertain about which one to install, please refer to our [Remediatio
 
 ## Enroll
 
-Since you created your account on the CrowdSec console, you can now enroll your Security Engine to your account.
+Since you created your account on the CrowdSec console, you can now [enroll your Security Engine to your account](https://app.crowdsec.net/security-engines?enroll-engine=true).
 
 To do so, you can find steps outlined [here](/console/enrollment.mdx).

--- a/crowdsec-docs/docs/getting_started/getting_started_on_windows.md
+++ b/crowdsec-docs/docs/getting_started/getting_started_on_windows.md
@@ -185,6 +185,6 @@ When done, you will need to enable the `cs-windows-firewall-bouncer` service and
 
 ## Enrolling your instance
 
-The next step is to enroll your instance with the [CrowdSec Console](https://app.crowdsec.net/signup).
+The next step is to enroll your instance with the [CrowdSec Console](https://app.crowdsec.net/security-engines?enroll-engine=true).
 
 For the benefits, please visit the [Console section](/console/intro.md).

--- a/crowdsec-docs/docs/getting_started/install.mdx
+++ b/crowdsec-docs/docs/getting_started/install.mdx
@@ -125,7 +125,7 @@ You need to deploy a [Remediation Component](/bouncers/intro.md) to enforce deci
 
 ## Enrolling your instance
 
-The next step is to enroll your instance with the [CrowdSec Console](https://app.crowdsec.net/signup).
+The next step is to enroll your instance with the [CrowdSec Console](https://app.crowdsec.net/security-engines?enroll-engine=true).
 
 For the benefits, please visit the [Console section](/console/intro.md).
 

--- a/crowdsec-docs/docs/getting_started/install_freebsd.md
+++ b/crowdsec-docs/docs/getting_started/install_freebsd.md
@@ -140,6 +140,6 @@ Then start again the CrowdSec' service  `service crowdsec start`.
 
 ## Enrolling your instance
 
-The next step is to enroll your instance with the [CrowdSec Console](https://app.crowdsec.net/signup).
+The next step is to enroll your instance with the [CrowdSec Console](https://app.crowdsec.net/security-engines?enroll-engine=true).
 
 For the benefits, please visit the [Console section](/console/intro.md).

--- a/crowdsec-docs/docs/getting_started/install_opnsense.md
+++ b/crowdsec-docs/docs/getting_started/install_opnsense.md
@@ -124,6 +124,6 @@ For more information on the topic:
 
 ## Enrolling your instance
 
-The next step is to enroll your instance with the [CrowdSec Console](https://app.crowdsec.net/signup).
+The next step is to enroll your instance with the [CrowdSec Console](https://app.crowdsec.net/security-engines?enroll-engine=true).
 
 For the benefits, please visit the [Console section](/console/intro.md).

--- a/crowdsec-docs/docs/getting_started/install_pfsense.md
+++ b/crowdsec-docs/docs/getting_started/install_pfsense.md
@@ -212,3 +212,8 @@ a viable solution, it has slower performance than the method described above,
 especially in terms of latency when receiving decision updates.
 It also required pfBlockerNG in addition to CrowdSec.
 
+## Enrolling your instance
+
+The next step is to enroll your instance with the [CrowdSec Console](https://app.crowdsec.net/security-engines?enroll-engine=true).
+
+For the benefits, please visit the [Console section](/console/intro.md).


### PR DESCRIPTION
whenever we link to console for enrollment purposes we should link to security-engines page with this query parameter as web team have implemented a nice QOL