### PR TITLE
add precisions about testing the CF worker bouncer on CF free plan

### DIFF
--- a/crowdsec-docs/unversioned/bouncers/cloudflare-workers.mdx
+++ b/crowdsec-docs/unversioned/bouncers/cloudflare-workers.mdx
@@ -25,14 +25,15 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 
 :::warning
-This remediation component heavily relies on Cloudflare Workers and KV store. It won't work without a paid Workers subscription.
+This Bouncer heavily relies on Cloudflare Workers and KV store. It works best on a paid Workers subscription.
+More explanation in the chapter [Test with Cloudflare free plan](#appendix--test-with-cloudflare-free-plan)
 :::
 
 :::warning
-After configuring and starting the remediation component, please see the [setting up worker fail mode](#setting-up-the-worker-route-fail-mode) section.  
+After configuring and starting the Bouncer, please see the [setting up worker fail mode](#setting-up-the-worker-route-fail-mode) section.  
 :::
 
-This remediation component deploys Cloudflare Worker in front of a Cloudflare Zone/Website, which checks if incoming request's IP address/Country/AS is present in a KV store and takes necessary remedial actions. It also periodically updates the KV store with CrowdSec LAPI's decisions.
+This Bouncer deploys Cloudflare Worker in front of a Cloudflare Zone/Website, which checks if incoming request's IP address/Country/AS is present in a KV store and takes necessary remedial actions. It also periodically updates the KV store with CrowdSec LAPI's decisions.
 
 ## Installation
 
@@ -239,29 +240,60 @@ sudo crowdsec-cloudflare-worker-bouncer -d
 
 ## Setting up the worker route fail mode
 
-The remediation component creates worker routes to make the workers act as a reverse proxy for your origin servers. The worker routes are created with the failover mode set to `Fail Closed`. There's no public Cloudflare API we can use to change/update it to `Fail Open` mode.
+The Bouncer creates worker routes to make the workers act as a reverse proxy for your origin servers. The worker routes are created with the failover mode set to `Fail Closed`. There's no public Cloudflare API we can use to change/update it to `Fail Open` mode.
 
 With `Fail Closed` mode, Routes in fail closed mode will display a Cloudflare 1027 error page to visitors if there's an error within the worker. This error could be triggered due to quotas exceeding your plan etc. Cloudflare doesn't mention all the possible scenarios which could trigger this error page. 
 
-Thus **we recommend you to manually override the failover mode to `Fail Open`** for all the worker routes created by our remediation component. With `Fail Open` mode the requests would bypass the worker and be served directly from your origin servers. Thus your website would continue to function even if there's an error within the worker.
+Thus **we recommend you to manually override the failover mode to `Fail Open`** for all the worker routes created by our Bouncer. With `Fail Open` mode the requests would bypass the worker and be served directly from your origin servers. Thus your website would continue to function even if there's an error within the worker.
 
 This can be done by following the steps below:
 
 1. Log in to the Cloudflare dashboard and select your account.
-2. For all the websites configured with the remediation component, do the following:
+2. For all the websites configured with the Bouncer, do the following:
 3. Click on the website's name to open the Website's Overview page.
 4. Click on the Worker Routes tab from the left menu.
 
 ![Worker Route](/img/bouncer/cloudflare-worker/cfsitedashboard.png)
 
-5. Click on the route created by the remediation component.
+5. Click on the route created by the Bouncer.
 6. Click on the Edit button.
 7. Click on the Request limit failure mode. Check the Fail open button.
 
 ![Fail Open](/img/bouncer/cloudflare-worker/cffailmode.png)
 
+## Appendix: Test with Cloudflare free plan
+Because of some hard limits/quotas in the free plan, this bouncer is the most efficient on the paid Cloudflare plan.
+But you can use it on the free plan none the less.
+In this section we'll explore:
+  - What the Cloudflare freeplan limitations are and The consequences of those limitations on the capabilities of the bouncer
+  - An example of using this Bouncer on the free plan without issues
 
-## Configuration Reference
+### Cloudflare freeplan limitations 
+Our Bouncer uses Cloudflare Workers and Workers KeyValue storage
+You can find their official documentation about limits there:
+   - [KeyValue storage limits by plan](https://developers.cloudflare.com/kv/platform/limits/)
+   - [Workers limits by plan](https://developers.cloudflare.com/workers/platform/limits/)
+
+The limits to focus on for the freeplan are (in order of importance):
+  - KV write 1K/day
+  - Requests handled by worker: 100k/day and 1K/minute
+
+The KV write limit of 1K per day is the main restrictive limit for our Bouncer as our decisions list (blocklist) is most of the time comprised of tens of thousands of IPs
+The number of request quota is not such a massive limitation depending on the popularity of your service, but considering all the Background Noise attacks that can occur in a day, don't forget that legitimate requests are not the only thing hitting your endpoint. 
+
+From those limitations two things happen:
+  - The blocklist initial storage in KV is trucated to 1K IPs BUT will periodically receive new decisions and remove expired ones. So, eventually you'll have many more than 1K IPs in the KV but it could take a while
+  - If you reach the Worker request limits, the worker will fail and the request will just passthrough until the quota is refreshed. ⚠️ You need to [properly setup the failmode](#setting-up-the-worker-route-fail-mode)
+
+
+### Use the Bouncer with Cloudflare free plan.
+The main limit we can influence is the number of decisions we send to the worker.
+In this section we'll configure the Bouncer to only send decisions made locally and skip the decisions from the community blocklist.
+
+Once the you have [auto-generated the configuration](#auto-config-generator), we'll restrict the origin of decisions being sent via the config parameter [crowdsec.only_include_decisions_from](#crowdseconly_include_decisions_from)
+Don't forget to [properly setup the failmode](#setting-up-the-worker-route-fail-mode)
+
+## Appendix: Configuration Reference
 
 ### `crowdsec.lapi_url`
 

--- a/crowdsec-docs/unversioned/bouncers/cloudflare-workers.mdx
+++ b/crowdsec-docs/unversioned/bouncers/cloudflare-workers.mdx
@@ -262,8 +262,8 @@ This can be done by following the steps below:
 ![Fail Open](/img/bouncer/cloudflare-worker/cffailmode.png)
 
 ## Appendix: Test with Cloudflare free plan
-Because of some hard limits/quotas in the free plan, this bouncer is the most efficient on the paid Cloudflare plan.
-But you can use it on the free plan none the less.
+Because of some hard limits/quotas in the free plan, this bouncer is the most efficient on the paid Cloudflare plan.   
+But you can use it on the free plan none the less.   
 In this section we'll explore:
   - What the Cloudflare freeplan limitations are and The consequences of those limitations on the capabilities of the bouncer
   - An example of using this Bouncer on the free plan without issues
@@ -274,24 +274,44 @@ You can find their official documentation about limits there:
    - [KeyValue storage limits by plan](https://developers.cloudflare.com/kv/platform/limits/)
    - [Workers limits by plan](https://developers.cloudflare.com/workers/platform/limits/)
 
-The limits to focus on for the freeplan are (in order of importance):
+The limits we'll focus on for running the bouncer on the freeplan are (in order of importance):
   - KV write 1K/day
   - Requests handled by worker: 100k/day and 1K/minute
 
-The KV write limit of 1K per day is the main restrictive limit for our Bouncer as our decisions list (blocklist) is most of the time comprised of tens of thousands of IPs
-The number of request quota is not such a massive limitation depending on the popularity of your service, but considering all the Background Noise attacks that can occur in a day, don't forget that legitimate requests are not the only thing hitting your endpoint. 
+The *KV write limit of 1K per day* is the main restrictive limit for our Bouncer as our decisions list (blocklist) is most of the time comprised of tens of thousands of IPs.    
+The *number of request quota* is not such a massive limitation depending on the popularity of your service, but considering all the Background Noise attacks that can occur in a day, don't forget that legitimate requests are not the only thing hitting your endpoint.   
 
 From those limitations two things happen:
-  - The blocklist initial storage in KV is trucated to 1K IPs BUT will periodically receive new decisions and remove expired ones. So, eventually you'll have many more than 1K IPs in the KV but it could take a while
-  - If you reach the Worker request limits, the worker will fail and the request will just passthrough until the quota is refreshed. ⚠️ You need to [properly setup the failmode](#setting-up-the-worker-route-fail-mode)
+  - The blocklist initial storage in KV is truncated to 1K IPs
+    - However, it will periodically receive new decisions and remove expired ones.
+    - So, eventually you'll have many more than 1K IPs in the KV but it could take a while
+  - If you reach the Worker request limits
+    - The worker will fail and the request will just passthrough until the quota is refreshed.
+    - ⚠️ You need to [properly setup the failmode](#setting-up-the-worker-route-fail-mode)
 
-
-### Use the Bouncer with Cloudflare free plan.
-The main limit we can influence is the number of decisions we send to the worker.
+### Quick Guide : Use the Bouncer with Cloudflare free plan.
+The main limit we can influence is the number of decisions we'll store in the KV storage.   
 In this section we'll configure the Bouncer to only send decisions made locally and skip the decisions from the community blocklist.
 
-Once the you have [auto-generated the configuration](#auto-config-generator), we'll restrict the origin of decisions being sent via the config parameter [crowdsec.only_include_decisions_from](#crowdseconly_include_decisions_from)
-Don't forget to [properly setup the failmode](#setting-up-the-worker-route-fail-mode)
+1. [Auto-generate the configuration](#auto-config-generator)
+2. We'll restrict the origin of decisions being sent to the KV
+  Using the config parameter [crowdsec.only_include_decisions_from](#crowdseconly_include_decisions_from)   
+  We'll restrict to the *decisions taken locally* based on your installed scenarios AND *descisions added manually* via the command line
+  ```yaml
+crowdsec_config:
+  [...]
+  only_include_decisions_from: ["cscli", "crowdsec"]
+  ```
+3. Don't forget to [properly setup the failmode](#setting-up-the-worker-route-fail-mode). This will avoid breaking your service once you reach the request quotas
+4. Test *adding descisions* either of type *ban* or *captcha*
+  ```bash
+    sudo cscli decisions add --ip 1.2.3.4 --type captcha
+  ```
+  You should be able to see it using:
+```bash
+  sudo cscli decisions list --origin cscli
+```
+  And within a few seconds it will be sent to the KV and the proper remediation should be applied to the requests from the specified IP
 
 ## Appendix: Configuration Reference
 
@@ -310,19 +330,19 @@ sudo cscli -oraw bouncers add cloudflarebouncer # -oraw flag can discarded for h
 
 ### `crowdsec.update_frequency`
 
-The bouncer will poll the CrowdSec every `update_frequency` interval.
+The bouncer will poll the CrowdSec every `update_frequency` interval. (default: 10s)
 
 ### `crowdsec.include_scenarios_containing`
 
-Ignore IPs banned for triggering scenarios not containing either of provided word. Example value ["ssh", "http"]
+Ignore IPs banned for triggering scenarios not containing either of provided word. Example value ["ssh", "http"] (default: includes all scenarios)
 
 ### `crowdsec.exclude_scenarios_containing`
 
-Ignore IPs banned for triggering scenarios containing either of provided word. Example value ["ssh", "http"]
+Ignore IPs banned for triggering scenarios containing either of provided word. Example value ["ssh", "http"] (default: exclude none)
 
 ### `crowdsec.only_include_decisions_from`
 
-Only include IPs banned due to decisions orginating from provided sources. eg value ["cscli", "crowdsec"]
+Only include IPs banned due to decisions orginating from provided sources. eg value ["cscli", "crowdsec"] (default: include all origins)
 
 ### `crowdsec.insecure_skip_verify`
 

--- a/crowdsec-docs/unversioned/bouncers/cloudflare-workers.mdx
+++ b/crowdsec-docs/unversioned/bouncers/cloudflare-workers.mdx
@@ -262,56 +262,58 @@ This can be done by following the steps below:
 ![Fail Open](/img/bouncer/cloudflare-worker/cffailmode.png)
 
 ## Appendix: Test with Cloudflare free plan
-Because of some hard limits/quotas in the free plan, this bouncer is the most efficient on the paid Cloudflare plan.   
-But you can use it on the free plan none the less.   
-In this section we'll explore:
-  - What the Cloudflare freeplan limitations are and The consequences of those limitations on the capabilities of the bouncer
-  - An example of using this Bouncer on the free plan without issues
+Using Cloudflare's free plan with our Bouncer requires to understand the constraints of the CloudFlare freeplan.   
+Despite these constraints, it's entirely feasible to leverage the Bouncer for enhanced security.   
 
-### Cloudflare freeplan limitations 
-Our Bouncer uses Cloudflare Workers and Workers KeyValue storage
-You can find their official documentation about limits there:
+In this section we'll guide you through:
+  - An overview of the Cloudflare free plan's limitations and their impact on Bouncer functionality
+  - A walkthrough for deploying the Bouncer within these constraints successfully
+
+### Understanding Cloudflare Free Plan Limitations
+Our Bouncer integrates with Cloudflare Workers and Workers KeyValue storage, subject to specific thresholds under the free plan.  
+For the complete detailed information, refer to Cloudflare's official documentation:
    - [KeyValue storage limits by plan](https://developers.cloudflare.com/kv/platform/limits/)
    - [Workers limits by plan](https://developers.cloudflare.com/workers/platform/limits/)
 
-The limits we'll focus on for running the bouncer on the freeplan are (in order of importance):
-  - KV write 1K/day
-  - Requests handled by worker: 100k/day and 1K/minute
+Key limitations to note for Bouncer operation on the free plan include:
+  - KV write: Up to 1K per day
+  - Worker Requests:Up to 100k per day or 1K per minute
 
-The *KV write limit of 1K per day* is the main restrictive limit for our Bouncer as our decisions list (blocklist) is most of the time comprised of tens of thousands of IPs.    
-The *number of request quota* is not such a massive limitation depending on the popularity of your service, but considering all the Background Noise attacks that can occur in a day, don't forget that legitimate requests are not the only thing hitting your endpoint.   
+*KV write limit of 1K per day*:   
+It's the primary limiting factor as the full decisions list (blocklist) passed on to the bouncer often exceeds tens of thousands of IPs.   
+  - It implies that the initial population of decisions in the Worker's KV will be truncated to 1K
+  - However, it will still periodically receive new decisions and remove expired ones.
+  - So, eventually you'll have many more than 1K IPs in the KV but it still diminishes the immediate effectiveness of the bouncer
 
-From those limitations two things happen:
-  - The blocklist initial storage in KV is truncated to 1K IPs
-    - However, it will periodically receive new decisions and remove expired ones.
-    - So, eventually you'll have many more than 1K IPs in the KV but it could take a while
-  - If you reach the Worker request limits
-    - The worker will fail and the request will just passthrough until the quota is refreshed.
-    - ⚠️ You need to [properly setup the failmode](#setting-up-the-worker-route-fail-mode)
+The *request quota*:
+While the request quota might seem ample, it's essential to remember that both legitimate traffic and potential attack patterns contribute to this total.   
+  - ⚠️ It's primordial to [properly setup the failmode](#setting-up-the-worker-route-fail-mode)
+  - With the failmode set to passthrough, when you reach the Worker request limits your service will stay available, but the bouncer won't apply remediation anymore
 
-### Quick Guide : Use the Bouncer with Cloudflare free plan.
-The main limit we can influence is the number of decisions we'll store in the KV storage.   
-In this section we'll configure the Bouncer to only send decisions made locally and skip the decisions from the community blocklist.
+### Quick Guide : Configuring the Bouncer on Cloudflare's Free Plan
+To adapt to the free plan's constraints, we can prioritize local decision-making and manual intervention over broader community-driven blocklists.   
+Here's how to set it up:
 
-1. [Auto-generate the configuration](#auto-config-generator)
-2. We'll restrict the origin of decisions being sent to the KV
-  Using the config parameter [crowdsec.only_include_decisions_from](#crowdseconly_include_decisions_from)   
-  We'll restrict to the *decisions taken locally* based on your installed scenarios AND *descisions added manually* via the command line
+1. *Configuration Setup*: Begin by [auto-generating the Bouncer configuration](#auto-config-generator).
+2. *Limiting Decision Sources*: Modify the configuration to prioritize decisions generated by your Security Engine and added manually.   
+  - Using the config parameter [crowdsec.only_include_decisions_from](#crowdseconly_include_decisions_from)   
   ```yaml
 crowdsec_config:
   [...]
   only_include_decisions_from: ["cscli", "crowdsec"]
   ```
-3. Don't forget to [properly setup the failmode](#setting-up-the-worker-route-fail-mode). This will avoid breaking your service once you reach the request quotas
-4. Test *adding descisions* either of type *ban* or *captcha*
+3. *Failmode Configuration*: It's crucial to [configure the failmode properly](#setting-up-the-worker-route-fail-mode) to ensure your service remains operational even when request quotas are reached.
+4. *Testing with manual decisions*: Verify the functionality by adding decisions manually, which should be promptly reflected in KV storage and enforced by the Bouncer.
   ```bash
     sudo cscli decisions add --ip 1.2.3.4 --type captcha
   ```
-  You should be able to see it using:
+  check your decisions has been added using:
 ```bash
   sudo cscli decisions list --origin cscli
 ```
   And within a few seconds it will be sent to the KV and the proper remediation should be applied to the requests from the specified IP
+
+  <!-- Screenshot of CF KV ? or something -->
 
 ## Appendix: Configuration Reference
 

--- a/crowdsec-docs/unversioned/bouncers/cloudflare-workers.mdx
+++ b/crowdsec-docs/unversioned/bouncers/cloudflare-workers.mdx
@@ -25,15 +25,15 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 
 :::warning
-This Bouncer heavily relies on Cloudflare Workers and KV store. It works best on a paid Workers subscription.
+This Remediation Component heavily relies on Cloudflare Workers and KV store. It works best on a paid Workers subscription.
 More explanation in the chapter [Test with Cloudflare free plan](#appendix--test-with-cloudflare-free-plan)
 :::
 
 :::warning
-After configuring and starting the Bouncer, please see the [setting up worker fail mode](#setting-up-the-worker-route-fail-mode) section.  
+After configuring and starting the Remediation Component, please see the [setting up worker fail mode](#setting-up-the-worker-route-fail-mode) section.  
 :::
 
-This Bouncer deploys Cloudflare Worker in front of a Cloudflare Zone/Website, which checks if incoming request's IP address/Country/AS is present in a KV store and takes necessary remedial actions. It also periodically updates the KV store with CrowdSec LAPI's decisions.
+This Remediation Component (aka Bouncer) deploys a Cloudflare Worker in front of a Cloudflare Zone/Website, which checks if incoming request's IP address/Country/AS is present in a KV store and takes necessary remedial actions. It also periodically updates the KV store with CrowdSec LAPI's decisions.
 
 ## Installation
 
@@ -65,13 +65,13 @@ sudo yum install crowdsec-cloudflare-worker-bouncer
 </Tabs>
 
 
-Then run the following commands to setup your bouncer:
+Then run the following commands to setup your Remediation Component:
 
 
 ```bash
 sudo crowdsec-cloudflare-worker-bouncer -g <CLOUDFLARE_TOKEN1>,<CLOUDFLARE_TOKEN2> -o /etc/crowdsec/bouncers/crowdsec-cloudflare-worker-bouncer.yaml # auto-generate cloudflare config for provided space separated tokens 
 sudo vi /etc/crowdsec/bouncers/crowdsec-cloudflare-worker-bouncer.yaml # review config and set `crowdsec.lapi_key` if haven't alread
-sudo systemctl start crowdsec-cloudflare-worker-bouncer # the bouncer now syncs the crowdsec decisions with cloudflare components.
+sudo systemctl start crowdsec-cloudflare-worker-bouncer # the Remediation Component now syncs the crowdsec decisions with cloudflare components.
 ```
 
 :::warning
@@ -82,13 +82,13 @@ Please configure your server to emit real IPs rather than cloudflare IPs in logs
 
 :::info
 
-If your bouncer is not installed on the same machine than LAPI, don't forget to set the `crowdsec_lapi_url` and `crowdsec.lapi_key` in the configuration file `/etc/crowdsec/bouncers/crowdsec-cloudflare-worker-bouncer.yaml`
+If your Remediation Component is not installed on the same machine than LAPI, don't forget to set the `crowdsec_lapi_url` and `crowdsec.lapi_key` in the configuration file `/etc/crowdsec/bouncers/crowdsec-cloudflare-worker-bouncer.yaml`
 
 :::
 
 :::note
 
-You need to run `sudo crowdsec-cloudflare-worker-bouncer -d` to cleanup exisiting cloudflare components created by bouncer before editing the config files.
+You need to run `sudo crowdsec-cloudflare-worker-bouncer -d` to cleanup exisiting cloudflare components created by Remediation Component before editing the config files.
 
 :::
 
@@ -110,7 +110,7 @@ cd crowdsec-cloudflare-worker-bouncer/
 sudo ./install.sh
 sudo crowdsec-cloudflare-worker-bouncer -g <CLOUDFLARE_TOKEN1>,<CLOUDFLARE_TOKEN2> -o /etc/crowdsec/bouncers/crowdsec-cloudflare-worker-bouncer.yaml # auto-generate cloudflare config for provided tokens 
 sudo vi /etc/crowdsec/bouncers/crowdsec-cloudflare-worker-bouncer.yaml # review config and set `crowdsec.lapi_key` if haven't already
-sudo systemctl start crowdsec-cloudflare-worker-bouncer # the bouncer now syncs the crowdsec decisions with cloudflare components.
+sudo systemctl start crowdsec-cloudflare-worker-bouncer # the Remediation Component now syncs the crowdsec decisions with cloudflare components.
 ```
 
 #### From source
@@ -132,12 +132,12 @@ sudo systemctl start crowdsec-cloudflare-worker-bouncer
 
 ![Architecture](/img/bouncer/cloudflare-worker/cfworkerarch.png)
 
-The bouncer does the following:
+The Remediation Component does the following:
 
 1. Create a Cloudflare Worker and a Worker KV per configured account.
 2. Create a Worker Route(s) per configured zone. Any request matching the route would be handled by the worker.
 3. For every matching incoming request, the worker checks whether it's IP, Country and AS have a decision against. It checks for this in it's KV store. If found it performs the corresponding remediation.
-4. The bouncer also periodically updates the KV store with the latest decisions from CrowdSec. 
+4. The Remediation Component also periodically updates the KV store with the latest decisions from CrowdSec. 
 
 ## Configuration
 
@@ -199,7 +199,7 @@ Alternatively, you can
 
 Go to [Tokens](https://dash.cloudflare.com/profile/api-tokens) and create the token. 
 
-The bouncer requires the follwing permissions to function.
+The Remediation Component requires the follwing permissions to function.
 
 ![image](/img/bouncer/cloudflare-worker/cloudflare_token_permissions.png)
 
@@ -231,7 +231,7 @@ sudo crowdsec-cloudflare-worker-bouncer -c ./cfg.yaml -g <TOKEN_1>,<TOKEN_2>...
 
 ### Cloudflare Cleanup
 
-This deletes all the Cloudflare infrastructure which was created by the bouncer.
+This deletes all the Cloudflare infrastructure which was created by the Remediation Component.
 
 Example Usage:
 ```bash
@@ -240,61 +240,61 @@ sudo crowdsec-cloudflare-worker-bouncer -d
 
 ## Setting up the worker route fail mode
 
-The Bouncer creates worker routes to make the workers act as a reverse proxy for your origin servers. The worker routes are created with the failover mode set to `Fail Closed`. There's no public Cloudflare API we can use to change/update it to `Fail Open` mode.
+The Remediation Component creates worker routes to make the workers act as a reverse proxy for your origin servers. The worker routes are created with the failover mode set to `Fail Closed`. There's no public Cloudflare API we can use to change/update it to `Fail Open` mode.
 
 With `Fail Closed` mode, Routes in fail closed mode will display a Cloudflare 1027 error page to visitors if there's an error within the worker. This error could be triggered due to quotas exceeding your plan etc. Cloudflare doesn't mention all the possible scenarios which could trigger this error page. 
 
-Thus **we recommend you to manually override the failover mode to `Fail Open`** for all the worker routes created by our Bouncer. With `Fail Open` mode the requests would bypass the worker and be served directly from your origin servers. Thus your website would continue to function even if there's an error within the worker.
+Thus **we recommend you to manually override the failover mode to `Fail Open`** for all the worker routes created by our Remediation Component. With `Fail Open` mode the requests would bypass the worker and be served directly from your origin servers. Thus your website would continue to function even if there's an error within the worker.
 
 This can be done by following the steps below:
 
 1. Log in to the Cloudflare dashboard and select your account.
-2. For all the websites configured with the Bouncer, do the following:
+2. For all the websites configured with the Remediation Component, do the following:
 3. Click on the website's name to open the Website's Overview page.
 4. Click on the Worker Routes tab from the left menu.
 
 ![Worker Route](/img/bouncer/cloudflare-worker/cfsitedashboard.png)
 
-5. Click on the route created by the Bouncer.
+5. Click on the route created by the Remediation Component.
 6. Click on the Edit button.
 7. Click on the Request limit failure mode. Check the Fail open button.
 
 ![Fail Open](/img/bouncer/cloudflare-worker/cffailmode.png)
 
 ## Appendix: Test with Cloudflare free plan
-Using Cloudflare's free plan with our Bouncer requires to understand the constraints of the CloudFlare freeplan.   
-Despite these constraints, it's entirely feasible to leverage the Bouncer for enhanced security.   
+Using Cloudflare's free plan with our Remediation Component requires to understand the constraints of the CloudFlare freeplan.   
+Despite these constraints, it's entirely feasible to leverage the Remediation Component for enhanced security.   
 
 In this section we'll guide you through:
-  - An overview of the Cloudflare free plan's limitations and their impact on Bouncer functionality
-  - A walkthrough for deploying the Bouncer within these constraints successfully
+  - An overview of the Cloudflare free plan's limitations and their impact on Remediation Component functionality
+  - A walkthrough for deploying the Remediation Component within these constraints successfully
 
 ### Understanding Cloudflare Free Plan Limitations
-Our Bouncer integrates with Cloudflare Workers and Workers KeyValue storage, subject to specific thresholds under the free plan.  
+Our Remediation Component integrates with Cloudflare Workers and Workers KeyValue storage, subject to specific thresholds under the free plan.  
 For the complete detailed information, refer to Cloudflare's official documentation:
    - [KeyValue storage limits by plan](https://developers.cloudflare.com/kv/platform/limits/)
    - [Workers limits by plan](https://developers.cloudflare.com/workers/platform/limits/)
 
-Key limitations to note for Bouncer operation on the free plan include:
+Key limitations to note for Remediation Component operation on the free plan include:
   - KV write: Up to 1K per day
   - Worker Requests:Up to 100k per day or 1K per minute
 
 *KV write limit of 1K per day*:   
-It's the primary limiting factor as the full decisions list (blocklist) passed on to the bouncer often exceeds tens of thousands of IPs.   
+It's the primary limiting factor as the full decisions list (blocklist) passed on to the Remediation Component often exceeds tens of thousands of IPs.   
   - It implies that the initial population of decisions in the Worker's KV will be truncated to 1K
   - However, it will still periodically receive new decisions and remove expired ones.
-  - So, eventually you'll have many more than 1K IPs in the KV but it still diminishes the immediate effectiveness of the bouncer
+  - So, eventually you'll have many more than 1K IPs in the KV but it still diminishes the immediate effectiveness of the Remediation Component
 
 The *request quota*:
 While the request quota might seem ample, it's essential to remember that both legitimate traffic and potential attack patterns contribute to this total.   
   - ⚠️ It's primordial to [properly setup the failmode](#setting-up-the-worker-route-fail-mode)
-  - With the failmode set to passthrough, when you reach the Worker request limits your service will stay available, but the bouncer won't apply remediation anymore
+  - With the failmode set to passthrough, when you reach the Worker request limits your service will stay available, but the Remediation Component won't apply remediation anymore
 
-### Quick Guide : Configuring the Bouncer on Cloudflare's Free Plan
+### Quick Guide : Configuring the Remediation Component on Cloudflare's Free Plan
 To adapt to the free plan's constraints, we can prioritize local decision-making and manual intervention over broader community-driven blocklists.   
 Here's how to set it up:
 
-1. *Configuration Setup*: Begin by [auto-generating the Bouncer configuration](#auto-config-generator).
+1. *Configuration Setup*: Begin by [auto-generating the Remediation Component configuration](#auto-config-generator).
 2. *Limiting Decision Sources*: Modify the configuration to prioritize decisions generated by your Security Engine and added manually.   
   - Using the config parameter [crowdsec.only_include_decisions_from](#crowdseconly_include_decisions_from)   
   ```yaml
@@ -303,7 +303,7 @@ crowdsec_config:
   only_include_decisions_from: ["cscli", "crowdsec"]
   ```
 3. *Failmode Configuration*: It's crucial to [configure the failmode properly](#setting-up-the-worker-route-fail-mode) to ensure your service remains operational even when request quotas are reached.
-4. *Testing with manual decisions*: Verify the functionality by adding decisions manually, which should be promptly reflected in KV storage and enforced by the Bouncer.
+4. *Testing with manual decisions*: Verify the functionality by adding decisions manually, which should be promptly reflected in KV storage and enforced by the Remediation Component.
   ```bash
     sudo cscli decisions add --ip 1.2.3.4 --type captcha
   ```
@@ -319,7 +319,7 @@ crowdsec_config:
 
 ### `crowdsec.lapi_url`
 
-The URL of CrowdSec LAPI. It should be accessible from the bouncer.
+The URL of CrowdSec LAPI. It should be accessible from the Remediation Component.
 
 ### `crowdsec.lapi_key`
 
@@ -332,7 +332,7 @@ sudo cscli -oraw bouncers add cloudflarebouncer # -oraw flag can discarded for h
 
 ### `crowdsec.update_frequency`
 
-The bouncer will poll the CrowdSec every `update_frequency` interval. (default: 10s)
+The Remediation Component will poll the CrowdSec every `update_frequency` interval. (default: 10s)
 
 ### `crowdsec.include_scenarios_containing`
 


### PR DESCRIPTION
Added a section in doc to guide user through using the Bouncer ont he Cloudflare free plan despite that plan's limitations
Additionnal section preview in Docusaurus : [Appendix: Test with Cloudflare free plan](https://pr-539.d1to60jd2gb6y6.amplifyapp.com/u/bouncers/cloudflare-workers#appendix-test-with-cloudflare-free-plan)