### PR TITLE
Fix wrong type in crowdsec_configuration docs for use_forwarded_for_headers

### DIFF
--- a/crowdsec-docs/docs/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/docs/configuration/crowdsec_configuration.md
@@ -911,7 +911,7 @@ cidrs:
 ```
 
 ##### `use_forwarded_for_headers`
-> string
+> bool
 
 Allow the usage of `X-Forwarded-For` or `X-Real-IP` to get the client IP address. Do not enable if you are not running the LAPI behind a trusted reverse-proxy or LB.
 

--- a/crowdsec-docs/versioned_docs/version-v1.5.0/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/versioned_docs/version-v1.5.0/configuration/crowdsec_configuration.md
@@ -823,7 +823,7 @@ cidrs:
 ```
 
 ##### `use_forwarded_for_headers`
-> string
+> bool
 
 Allow the usage of `X-Forwarded-For` or `X-Real-IP` to get the client IP address. Do not enable if you are not running the LAPI behind a trusted reverse-proxy or LB.
 


### PR DESCRIPTION
The documentation states that the `use_forwarded_for_headers` directive has the type `string` on one instance, but it's a `bool`