### PR TITLE
Set a more generic way to acquire all event from journald

### DIFF
--- a/crowdsec-docs/docs/data_sources/journald.md
+++ b/crowdsec-docs/docs/data_sources/journald.md
@@ -18,6 +18,35 @@ labels:
   type: syslog
 ```
 
+Rather to specify each systemd service, you could also decide to acquire more informations from journald by referrencing a filter from _TRANSPORT
+
+```yaml
+---
+source: journalctl
+journalctl_filter:
+  - "_TRANSPORT=journal"
+labels:
+  type: syslog
+---
+source: journalctl
+journalctl_filter:
+  - "_TRANSPORT=syslog"
+labels:
+  type: syslog
+---
+source: journalctl
+journalctl_filter:
+  - "_TRANSPORT=stdout"
+labels:
+  type: syslog
+---
+source: journalctl
+journalctl_filter:
+  - "_TRANSPORT=kernel"
+labels:
+  type: syslog
+---
+```
 ## Parameters
 
 ### `journalctl_filter`


### PR DESCRIPTION
It is possible to get more informations easily rather that specify for each services

https://www.man7.org/linux/man-pages/man7/systemd.journal-fields.7.html