### PR TITLE
fix: config file links

### DIFF
--- a/crowdsec-docs/docs/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/docs/configuration/crowdsec_configuration.md
@@ -9,95 +9,10 @@ CrowdSec has a main `yaml` configuration file, usually located in `/etc/crowdsec
 
 ## Configuration example
 
-<details>
-  <summary>Default configuration</summary>
+You can find the default configurations on our GitHub repository:
 
-```yaml
-common:
-  daemonize: true
-  pid_dir: /var/run/
-  log_media: file
-  log_level: info
-  log_dir: /var/log/
-  log_max_size: 500
-  log_max_age: 28
-  log_max_files: 3
-  compress_logs: true
-  working_dir: .
-config_paths:
-  config_dir: /etc/crowdsec/
-  data_dir: /var/lib/crowdsec/data/
-  simulation_path: /etc/crowdsec/simulation.yaml
-  hub_dir: /etc/crowdsec/hub/
-  index_path: /etc/crowdsec/hub/.index.json
-  notification_dir: /etc/crowdsec/notifications/
-  plugin_dir: /var/lib/crowdsec/plugins/
-  pattern_dir: /etc/crowdsec/patterns/
-crowdsec_service:
-  enable: true
-  acquisition_path: /etc/crowdsec/acquis.yaml
-  console_context_path: /etc/crowdsec/console/context.yaml
-  #acquisition_dir: /etc/crowdsec/acquis/
-  parser_routines: 1
-  buckets_routines: 1
-  output_routines: 1
-cscli:
-  output: human
-  hub_branch: wip_lapi
-db_config:
-  log_level: info
-  type: sqlite
-  db_path: /var/lib/crowdsec/data/crowdsec.db
-  #max_open_conns: 100
-  #user:
-  #password:
-  #db_name:
-  #host:
-  #port:
-  #use_wal: false
-  flush:
-    max_items: 5000
-    max_age: 7d
-    #bouncers_autodelete:
-    #  cert: 7d
-    #  api_key: 7d
-    #agents_autodelete:
-    #  cert: 7d
-    #  login_password: 7d
-api:
-  client:
-    insecure_skip_verify: false
-    credentials_path: /etc/crowdsec/local_api_credentials.yaml
-  server:
-    enable: true
-    log_level: info
-    listen_uri: 127.0.0.1:8080
-    profiles_path: /etc/crowdsec/profiles.yaml
-    use_forwarded_for_headers: false
-    console_path: /etc/crowdsec/console.yaml
-    online_client: # Crowdsec API
-      credentials_path: /etc/crowdsec/online_api_credentials.yaml
-#    disable_remote_lapi_registration: false
-#    capi_whitelists_path: /etc/crowdsec/capi_whitelists.yaml
-#    tls:
-#      cert_file: /etc/crowdsec/ssl/cert.pem
-#      key_file: /etc/crowdsec/ssl/key.pem
-#      client_verification: "VerifyClientCertIfGiven"
-#      ca_cert_path: /path/to/ca.crt
-#      agents_allowed_ou: # List of allowed Organisational Unit for the agents
-#       - agents_ou
-#      bouncers_allowed_ou: # List of allowed Organisational Unit for the bouncers
-#       - bouncers_ou
-#      crl_path: /path/to/file.crl
-#      cache_expiration: 1h
-prometheus:
-  enabled: true
-  level: full
-  listen_addr: 127.0.0.1
-  listen_port: 6060
-```
-
-</details>
+[Linux default configuration](https://github.com/crowdsecurity/crowdsec/blob/master/config/config.yaml)
+[Windows default configuration](https://github.com/crowdsecurity/crowdsec/blob/master/config/config_win.yaml)
 
 ## Environment variables
 

--- a/crowdsec-docs/docs/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/docs/configuration/crowdsec_configuration.md
@@ -12,6 +12,7 @@ CrowdSec has a main `yaml` configuration file, usually located in `/etc/crowdsec
 You can find the default configurations on our GitHub repository:
 
 [Linux default configuration](https://github.com/crowdsecurity/crowdsec/blob/master/config/config.yaml)
+
 [Windows default configuration](https://github.com/crowdsecurity/crowdsec/blob/master/config/config_win.yaml)
 
 ## Environment variables

--- a/crowdsec-docs/versioned_docs/version-v1.3.4/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/versioned_docs/version-v1.3.4/configuration/crowdsec_configuration.md
@@ -9,75 +9,9 @@ CrowdSec has a main `yaml` configuration file, usually located in `/etc/crowdsec
 
 ## Configuration example
 
+You can find the default configurations on our GitHub repository:
 
-<details>
-  <summary>Default configuration</summary>
-
-```yaml
-common:
-  daemonize: true
-  pid_dir: /var/run/
-  log_media: file
-  log_level: info
-  log_dir: /var/log/
-  log_max_size: 500
-  log_max_age: 28
-  log_max_files: 3
-  compress_logs: true
-  working_dir: .
-config_paths:
-  config_dir: /etc/crowdsec/
-  data_dir: /var/lib/crowdsec/data/
-  simulation_path: /etc/crowdsec/simulation.yaml
-  hub_dir: /etc/crowdsec/hub/
-  index_path: /etc/crowdsec/hub/.index.json
-  notification_dir: /etc/crowdsec/notifications/
-  plugin_dir: /var/lib/crowdsec/plugins/
-crowdsec_service:
-  acquisition_path: /etc/crowdsec/acquis.yaml
-  #acquisition_dir: /etc/crowdsec/acquis/
-  parser_routines: 1
-  buckets_routines: 1
-  output_routines: 1
-cscli:
-  output: human
-  hub_branch: wip_lapi
-db_config:
-  log_level: info
-  type: sqlite
-  db_path: /var/lib/crowdsec/data/crowdsec.db
-  #max_open_conns: 100
-  #user:
-  #password:
-  #db_name:
-  #host:
-  #port:
-  flush:
-    max_items: 5000
-    max_age: 7d
-api:
-  client:
-    insecure_skip_verify: false
-    credentials_path: /etc/crowdsec/local_api_credentials.yaml
-  server:
-    log_level: info
-    listen_uri: 127.0.0.1:8080
-    profiles_path: /etc/crowdsec/profiles.yaml
-    use_forwarded_for_headers: false
-    console_path: /etc/crowdsec/console.yaml
-    online_client: # Crowdsec API
-      credentials_path: /etc/crowdsec/online_api_credentials.yaml
-#    tls:
-#      cert_file: /etc/crowdsec/ssl/cert.pem
-#      key_file: /etc/crowdsec/ssl/key.pem
-prometheus:
-  enabled: true
-  level: full
-  listen_addr: 127.0.0.1
-  listen_port: 6060
-```
-
-</details>
+[Linux default configuration](https://github.com/crowdsecurity/crowdsec/blob/releases/1.3.x/config/config.yaml)
 
 ## Environment variable
 

--- a/crowdsec-docs/versioned_docs/version-v1.4.0/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/versioned_docs/version-v1.4.0/configuration/crowdsec_configuration.md
@@ -9,88 +9,10 @@ CrowdSec has a main `yaml` configuration file, usually located in `/etc/crowdsec
 
 ## Configuration example
 
-<details>
-  <summary>Default configuration</summary>
+You can find the default configurations on our GitHub repository:
 
-```yaml
-common:
-  daemonize: true
-  pid_dir: /var/run/
-  log_media: file
-  log_level: info
-  log_dir: /var/log/
-  log_max_size: 500
-  log_max_age: 28
-  log_max_files: 3
-  compress_logs: true
-  working_dir: .
-config_paths:
-  config_dir: /etc/crowdsec/
-  data_dir: /var/lib/crowdsec/data/
-  simulation_path: /etc/crowdsec/simulation.yaml
-  hub_dir: /etc/crowdsec/hub/
-  index_path: /etc/crowdsec/hub/.index.json
-  notification_dir: /etc/crowdsec/notifications/
-  plugin_dir: /var/lib/crowdsec/plugins/
-crowdsec_service:
-  acquisition_path: /etc/crowdsec/acquis.yaml
-  #acquisition_dir: /etc/crowdsec/acquis/
-  parser_routines: 1
-  buckets_routines: 1
-  output_routines: 1
-cscli:
-  output: human
-  hub_branch: wip_lapi
-db_config:
-  log_level: info
-  type: sqlite
-  db_path: /var/lib/crowdsec/data/crowdsec.db
-  #max_open_conns: 100
-  #user:
-  #password:
-  #db_name:
-  #host:
-  #port:
-  flush:
-    max_items: 5000
-    max_age: 7d
-    #bouncers_autodelete:
-    #  cert: 7d
-    #  api_key: 7d
-    #agents_autodelete:
-    #  cert: 7d
-    #  login_password: 7d
-api:
-  client:
-    insecure_skip_verify: false
-    credentials_path: /etc/crowdsec/local_api_credentials.yaml
-  server:
-    log_level: info
-    listen_uri: 127.0.0.1:8080
-    profiles_path: /etc/crowdsec/profiles.yaml
-    use_forwarded_for_headers: false
-    console_path: /etc/crowdsec/console.yaml
-    online_client: # Crowdsec API
-      credentials_path: /etc/crowdsec/online_api_credentials.yaml
-#    tls:
-#      cert_file: /etc/crowdsec/ssl/cert.pem
-#      key_file: /etc/crowdsec/ssl/key.pem
-#      client_verification: "VerifyClientCertIfGiven"
-#      ca_cert_path: /path/to/ca.crt
-#      agents_allowed_ou: # List of allowed Organisational Unit for the agents
-#       - agents_ou
-#      bouncers_allowed_ou: # List of allowed Organisational Unit for the bouncers
-#       - bouncers_ou
-#      crl_path: /path/to/file.crl
-#      cache_expiration: 1h
-prometheus:
-  enabled: true
-  level: full
-  listen_addr: 127.0.0.1
-  listen_port: 6060
-```
-
-</details>
+[Linux default configuration](https://github.com/crowdsecurity/crowdsec/blob/releases/1.4.x/config/config.yaml)
+[Windows default configuration](https://github.com/crowdsecurity/crowdsec/blob/releases/1.4.x/config/config_win.yaml)
 
 ## Environment variables
 

--- a/crowdsec-docs/versioned_docs/version-v1.4.0/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/versioned_docs/version-v1.4.0/configuration/crowdsec_configuration.md
@@ -12,6 +12,7 @@ CrowdSec has a main `yaml` configuration file, usually located in `/etc/crowdsec
 You can find the default configurations on our GitHub repository:
 
 [Linux default configuration](https://github.com/crowdsecurity/crowdsec/blob/releases/1.4.x/config/config.yaml)
+
 [Windows default configuration](https://github.com/crowdsecurity/crowdsec/blob/releases/1.4.x/config/config_win.yaml)
 
 ## Environment variables

--- a/crowdsec-docs/versioned_docs/version-v1.5.0/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/versioned_docs/version-v1.5.0/configuration/crowdsec_configuration.md
@@ -9,93 +9,10 @@ CrowdSec has a main `yaml` configuration file, usually located in `/etc/crowdsec
 
 ## Configuration example
 
-<details>
-  <summary>Default configuration</summary>
+You can find the default configurations on our GitHub repository:
 
-```yaml
-common:
-  daemonize: true
-  pid_dir: /var/run/
-  log_media: file
-  log_level: info
-  log_dir: /var/log/
-  log_max_size: 500
-  log_max_age: 28
-  log_max_files: 3
-  compress_logs: true
-  working_dir: .
-config_paths:
-  config_dir: /etc/crowdsec/
-  data_dir: /var/lib/crowdsec/data/
-  simulation_path: /etc/crowdsec/simulation.yaml
-  hub_dir: /etc/crowdsec/hub/
-  index_path: /etc/crowdsec/hub/.index.json
-  notification_dir: /etc/crowdsec/notifications/
-  plugin_dir: /var/lib/crowdsec/plugins/
-crowdsec_service:
-  enable: true
-  acquisition_path: /etc/crowdsec/acquis.yaml
-  console_context_path: /etc/crowdsec/console/context.yaml
-  #acquisition_dir: /etc/crowdsec/acquis/
-  parser_routines: 1
-  buckets_routines: 1
-  output_routines: 1
-cscli:
-  output: human
-  hub_branch: wip_lapi
-db_config:
-  log_level: info
-  type: sqlite
-  db_path: /var/lib/crowdsec/data/crowdsec.db
-  #max_open_conns: 100
-  #user:
-  #password:
-  #db_name:
-  #host:
-  #port:
-  #use_wal: false
-  flush:
-    max_items: 5000
-    max_age: 7d
-    #bouncers_autodelete:
-    #  cert: 7d
-    #  api_key: 7d
-    #agents_autodelete:
-    #  cert: 7d
-    #  login_password: 7d
-api:
-  client:
-    insecure_skip_verify: false
-    credentials_path: /etc/crowdsec/local_api_credentials.yaml
-  server:
-    enable: true
-    log_level: info
-    listen_uri: 127.0.0.1:8080
-    profiles_path: /etc/crowdsec/profiles.yaml
-    use_forwarded_for_headers: false
-    console_path: /etc/crowdsec/console.yaml
-    online_client: # Crowdsec API
-      credentials_path: /etc/crowdsec/online_api_credentials.yaml
-#    capi_whitelists_path: /etc/crowdsec/capi_whitelists.yaml
-#    tls:
-#      cert_file: /etc/crowdsec/ssl/cert.pem
-#      key_file: /etc/crowdsec/ssl/key.pem
-#      client_verification: "VerifyClientCertIfGiven"
-#      ca_cert_path: /path/to/ca.crt
-#      agents_allowed_ou: # List of allowed Organisational Unit for the agents
-#       - agents_ou
-#      bouncers_allowed_ou: # List of allowed Organisational Unit for the bouncers
-#       - bouncers_ou
-#      crl_path: /path/to/file.crl
-#      cache_expiration: 1h
-prometheus:
-  enabled: true
-  level: full
-  listen_addr: 127.0.0.1
-  listen_port: 6060
-```
-
-</details>
+[Linux default configuration](https://github.com/crowdsecurity/crowdsec/blob/releases/1.5.x/config/config.yaml)
+[Windows default configuration](https://github.com/crowdsecurity/crowdsec/blob/releases/1.5.x/config/config_win.yaml)
 
 ## Environment variables
 

--- a/crowdsec-docs/versioned_docs/version-v1.5.0/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/versioned_docs/version-v1.5.0/configuration/crowdsec_configuration.md
@@ -12,6 +12,7 @@ CrowdSec has a main `yaml` configuration file, usually located in `/etc/crowdsec
 You can find the default configurations on our GitHub repository:
 
 [Linux default configuration](https://github.com/crowdsecurity/crowdsec/blob/releases/1.5.x/config/config.yaml)
+
 [Windows default configuration](https://github.com/crowdsecurity/crowdsec/blob/releases/1.5.x/config/config_win.yaml)
 
 ## Environment variables

--- a/crowdsec-docs/versioned_docs/version-v1.6.0/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/versioned_docs/version-v1.6.0/configuration/crowdsec_configuration.md
@@ -12,6 +12,7 @@ CrowdSec has a main `yaml` configuration file, usually located in `/etc/crowdsec
 You can find the default configurations on our GitHub repository:
 
 [Linux default configuration](https://github.com/crowdsecurity/crowdsec/blob/master/config/config.yaml)
+
 [Windows default configuration](https://github.com/crowdsecurity/crowdsec/blob/master/config/config_win.yaml)
 
 ## Environment variables

--- a/crowdsec-docs/versioned_docs/version-v1.6.0/configuration/crowdsec_configuration.md
+++ b/crowdsec-docs/versioned_docs/version-v1.6.0/configuration/crowdsec_configuration.md
@@ -9,94 +9,10 @@ CrowdSec has a main `yaml` configuration file, usually located in `/etc/crowdsec
 
 ## Configuration example
 
-<details>
-  <summary>Default configuration</summary>
+You can find the default configurations on our GitHub repository:
 
-```yaml
-common:
-  daemonize: true
-  pid_dir: /var/run/
-  log_media: file
-  log_level: info
-  log_dir: /var/log/
-  log_max_size: 500
-  log_max_age: 28
-  log_max_files: 3
-  compress_logs: true
-  working_dir: .
-config_paths:
-  config_dir: /etc/crowdsec/
-  data_dir: /var/lib/crowdsec/data/
-  simulation_path: /etc/crowdsec/simulation.yaml
-  hub_dir: /etc/crowdsec/hub/
-  index_path: /etc/crowdsec/hub/.index.json
-  notification_dir: /etc/crowdsec/notifications/
-  plugin_dir: /var/lib/crowdsec/plugins/
-crowdsec_service:
-  enable: true
-  acquisition_path: /etc/crowdsec/acquis.yaml
-  console_context_path: /etc/crowdsec/console/context.yaml
-  #acquisition_dir: /etc/crowdsec/acquis/
-  parser_routines: 1
-  buckets_routines: 1
-  output_routines: 1
-cscli:
-  output: human
-  hub_branch: wip_lapi
-db_config:
-  log_level: info
-  type: sqlite
-  db_path: /var/lib/crowdsec/data/crowdsec.db
-  #max_open_conns: 100
-  #user:
-  #password:
-  #db_name:
-  #host:
-  #port:
-  #use_wal: false
-  flush:
-    max_items: 5000
-    max_age: 7d
-    #bouncers_autodelete:
-    #  cert: 7d
-    #  api_key: 7d
-    #agents_autodelete:
-    #  cert: 7d
-    #  login_password: 7d
-api:
-  client:
-    insecure_skip_verify: false
-    credentials_path: /etc/crowdsec/local_api_credentials.yaml
-  server:
-    enable: true
-    log_level: info
-    listen_uri: 127.0.0.1:8080
-    profiles_path: /etc/crowdsec/profiles.yaml
-    use_forwarded_for_headers: false
-    console_path: /etc/crowdsec/console.yaml
-    online_client: # Crowdsec API
-      credentials_path: /etc/crowdsec/online_api_credentials.yaml
-#    disable_remote_lapi_registration: false
-#    capi_whitelists_path: /etc/crowdsec/capi_whitelists.yaml
-#    tls:
-#      cert_file: /etc/crowdsec/ssl/cert.pem
-#      key_file: /etc/crowdsec/ssl/key.pem
-#      client_verification: "VerifyClientCertIfGiven"
-#      ca_cert_path: /path/to/ca.crt
-#      agents_allowed_ou: # List of allowed Organisational Unit for the agents
-#       - agents_ou
-#      bouncers_allowed_ou: # List of allowed Organisational Unit for the bouncers
-#       - bouncers_ou
-#      crl_path: /path/to/file.crl
-#      cache_expiration: 1h
-prometheus:
-  enabled: true
-  level: full
-  listen_addr: 127.0.0.1
-  listen_port: 6060
-```
-
-</details>
+[Linux default configuration](https://github.com/crowdsecurity/crowdsec/blob/master/config/config.yaml)
+[Windows default configuration](https://github.com/crowdsecurity/crowdsec/blob/master/config/config_win.yaml)
 
 ## Environment variables
 


### PR DESCRIPTION
fix #581 

Instead of having the yaml coded into the page link to the github repo for that version