### PR TITLE
SideBar relative link bug fix

### DIFF
--- a/crowdsec-docs/sidebars.js
+++ b/crowdsec-docs/sidebars.js
@@ -88,7 +88,7 @@
                 },
                 {
                     type: 'link',
-                    id: 'appsec/intro',
+                    href: '/./appsec/intro',
                     label: 'AppSec',
                 },
                 {

--- a/crowdsec-docs/sidebars.js
+++ b/crowdsec-docs/sidebars.js
@@ -87,8 +87,8 @@
                     href: '/u/bouncers/intro',
                 },
                 {
-                    type: 'link',
-                    href: '/./appsec/intro',
+                    type: 'doc',
+                    id: 'appsec/intro',
                     label: 'AppSec',
                 },
                 {

--- a/crowdsec-docs/sidebars.js
+++ b/crowdsec-docs/sidebars.js
@@ -88,7 +88,7 @@
                 },
                 {
                     type: 'link',
-                    href: 'appsec/intro',
+                    id: 'appsec/intro',
                     label: 'AppSec',
                 },
                 {


### PR DESCRIPTION
To reproduce bug

you go there https://doc.crowdsec.net/docs/next/parsers/intro (Parser hierarchy selected)
then in sidebar you click on AppSec
It messes up and only changes the last bit of the path and takes us to https://doc.crowdsec.net/docs/next/parsers/appsec/intro

I guess it's handling relative href badly href: 'appsec/intro'