### PR TITLE
enhance: Whitelist change name key to not conflict with our official one

### DIFF
--- a/crowdsec-docs/docs/whitelist/expr_based_whitelist.md
+++ b/crowdsec-docs/docs/whitelist/expr_based_whitelist.md
@@ -8,7 +8,7 @@ Let's whitelist a **specific** user-agent (of course, it's just an example, don'
 Since we are using data that is present from the parsing stage we can do this within `Parsing Whitelist` level. Please see [introduction](/whitelist/introduction.md) for your OS specific paths.
 
 ```yaml
-name: crowdsecurity/whitelists
+name: "my/whitelist" ## Must be unique
 description: "Whitelist events from private ipv4 addresses"
 whitelist:
   reason: "private ipv4 ranges"
@@ -116,7 +116,7 @@ line: 5.5.8.5 - - [04/Jan/2020:07:25:02 +0000] "GET /.well-known/acme-challenge/
 	|		├ create evt.Parsed.static_ressource : false
 	|		├ create evt.Parsed.file_dir : /.well-known/acme-challenge/
 	|		├ create evt.Meta.http_args_len : 0
-	|	└ 🟢 crowdsecurity/whitelists (unchanged)
+	|	└ 🟢 my/whitelist (unchanged)
 	├-------- parser success 🟢
 	├ Scenarios
 		├ 🟢 crowdsecurity/http-crawl-non_statics

--- a/crowdsec-docs/docs/whitelist/format.md
+++ b/crowdsec-docs/docs/whitelist/format.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 ## Whitelist configuration example
 
 ```yaml
-name: crowdsecurity/my-whitelists
+name: "my/whitelist" ## Must be unique
 description: "Whitelist events from my ipv4 addresses"
 #it's a normal parser, so we can restrict its scope with filter
 filter: "1 == 1"

--- a/crowdsec-docs/docs/whitelist/fqdn_based_whitelist.md
+++ b/crowdsec-docs/docs/whitelist/fqdn_based_whitelist.md
@@ -14,7 +14,7 @@ You might want to whitelist a fully qualified domain name (FQDN eg foo.com), in 
 Let's create the following file `FQDN-whitelists.yaml` (See [introduction](/whitelist/introduction.md) for your OS specific path) :
 
 ```yaml
-name: me/FQDN-whitlists
+name: "my/FQDN-whitlists" ## Must be unique
 description: "Whitelist postoverflows from FQDN"
 whitelist:
   reason: "do whitelistings by FQDN"

--- a/crowdsec-docs/docs/whitelist/ip_based_whitelist.md
+++ b/crowdsec-docs/docs/whitelist/ip_based_whitelist.md
@@ -8,7 +8,7 @@ IP whitelists are best suited at `Parser whitelists` level because once the log 
 We will create the file `mywhitelist.yaml` please see [introduction](/whitelist/introduction.md) for your OS specific paths.
 
 ```yaml
-name: crowdsecurity/whitelists
+name: "my/whitelist" ## Must be unique
 description: "Whitelist events from my ip addresses"
 whitelist:
   reason: "my ip ranges"

--- a/crowdsec-docs/docs/whitelist/postoverflow_based_whitelist.md
+++ b/crowdsec-docs/docs/whitelist/postoverflow_based_whitelist.md
@@ -24,7 +24,7 @@ First of all, install the [crowdsecurity/rdns postoverflow](https://hub.crowdsec
 Let's create `mywhitelist.yaml` again but remember this is a postoverflow whitelist so the paths will be different to `Parsing whitelists` please see [introduction](/whitelist/introduction.md) for your OS specific path.
 
 ```yaml
-name: me/my_cool_whitelist
+name: "my/po_whitelist" ## Must be unique
 description: lets whitelist our own reverse dns
 whitelist:
     reason: dont ban my ISP

--- a/crowdsec-docs/versioned_docs/version-v1.3.4/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.3.4/whitelist/create.md
@@ -43,7 +43,7 @@ sudo cscli decisions list
 Let's create a `/etc/crowdsec/parsers/s02-enrich/mywhitelists.yaml` file with the following content :
 
 ```yaml
-name: crowdsecurity/whitelists
+name: my/whitelist
 description: "Whitelist events from my ip addresses"
 whitelist:
   reason: "my ip ranges"
@@ -85,7 +85,7 @@ Now, let's make something more tricky : let's whitelist a **specific** user-agen
 Let's change our whitelist to :
 
 ```yaml
-name: crowdsecurity/whitelists
+name: my/whitelist
 description: "Whitelist events from private ipv4 addresses"
 whitelist:
   reason: "private ipv4 ranges"

--- a/crowdsec-docs/versioned_docs/version-v1.4.0/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.4.0/whitelist/create.md
@@ -43,7 +43,7 @@ sudo cscli decisions list
 Let's create a `/etc/crowdsec/parsers/s02-enrich/mywhitelists.yaml` file with the following content :
 
 ```yaml
-name: crowdsecurity/whitelists
+name: my/whitelist
 description: "Whitelist events from my ip addresses"
 whitelist:
   reason: "my ip ranges"
@@ -85,7 +85,7 @@ Now, let's make something more tricky : let's whitelist a **specific** user-agen
 Let's change our whitelist to :
 
 ```yaml
-name: crowdsecurity/whitelists
+name: my/whitelist
 description: "Whitelist events from private ipv4 addresses"
 whitelist:
   reason: "private ipv4 ranges"

--- a/crowdsec-docs/versioned_docs/version-v1.5.0/whitelist/create.md
+++ b/crowdsec-docs/versioned_docs/version-v1.5.0/whitelist/create.md
@@ -43,7 +43,7 @@ sudo cscli decisions list
 Let's create a `/etc/crowdsec/parsers/s02-enrich/mywhitelists.yaml` file with the following content :
 
 ```yaml
-name: crowdsecurity/whitelists
+name: my/whitelist
 description: "Whitelist events from my ip addresses"
 whitelist:
   reason: "my ip ranges"
@@ -85,7 +85,7 @@ Now, let's make something more tricky : let's whitelist a **specific** user-agen
 Let's change our whitelist to :
 
 ```yaml
-name: crowdsecurity/whitelists
+name: my/whitelist
 description: "Whitelist events from private ipv4 addresses"
 whitelist:
   reason: "private ipv4 ranges"

--- a/crowdsec-docs/versioned_docs/version-v1.6.0/whitelist/expr_based_whitelist.md
+++ b/crowdsec-docs/versioned_docs/version-v1.6.0/whitelist/expr_based_whitelist.md
@@ -8,7 +8,7 @@ Let's whitelist a **specific** user-agent (of course, it's just an example, don'
 Since we are using data that is present from the parsing stage we can do this within `Parsing Whitelist` level. Please see [introduction](/whitelist/introduction.md) for your OS specific paths.
 
 ```yaml
-name: crowdsecurity/whitelists
+name: my/whitelist
 description: "Whitelist events from private ipv4 addresses"
 whitelist:
   reason: "private ipv4 ranges"
@@ -116,7 +116,7 @@ line: 5.5.8.5 - - [04/Jan/2020:07:25:02 +0000] "GET /.well-known/acme-challenge/
 	|		├ create evt.Parsed.static_ressource : false
 	|		├ create evt.Parsed.file_dir : /.well-known/acme-challenge/
 	|		├ create evt.Meta.http_args_len : 0
-	|	└ 🟢 crowdsecurity/whitelists (unchanged)
+	|	└ 🟢 my/whitelist (unchanged)
 	├-------- parser success 🟢
 	├ Scenarios
 		├ 🟢 crowdsecurity/http-crawl-non_statics

--- a/crowdsec-docs/versioned_docs/version-v1.6.0/whitelist/ip_based_whitelist.md
+++ b/crowdsec-docs/versioned_docs/version-v1.6.0/whitelist/ip_based_whitelist.md
@@ -8,7 +8,7 @@ IP whitelists are best suited at `Parser whitelists` level because once the log 
 We will create the file `mywhitelist.yaml` please see [introduction](/whitelist/introduction.md) for your OS specific paths.
 
 ```yaml
-name: crowdsecurity/whitelists
+name: my/whitelist
 description: "Whitelist events from my ip addresses"
 whitelist:
   reason: "my ip ranges"


### PR DESCRIPTION
Some users will just copy and paste, not to know they need to change the name key, so change this to be something other than the official one and add a comment on the latest docs to say "Must be unique" to try inform them to change it.