### PR TITLE
Update custom bouncer code block to match others on pgae

### DIFF
--- a/crowdsec-docs/unversioned/bouncers/custom.mdx
+++ b/crowdsec-docs/unversioned/bouncers/custom.mdx
@@ -117,7 +117,7 @@ sudo systemctl enable --now crowdsec-custom-bouncer
 ## Default configuration
 
 ```sh
-$ vim /etc/crowdsec/bouncers/crowdsec-custom-bouncer.yaml
+sudo vim /etc/crowdsec/bouncers/crowdsec-custom-bouncer.yaml
 ```
 
 ```yaml


### PR DESCRIPTION
Change command line so it matches the other steps

The existing block has a $ character in the beginning which breaks being able to copy the code block and paste it into your terminal.
The other code blocks also use sudo so I followed that convention 