### PR TITLE
fix: update traefik middleware apiVersion

### DIFF
--- a/crowdsec-docs/unversioned/getting_started/installation/kubernetes.mdx
+++ b/crowdsec-docs/unversioned/getting_started/installation/kubernetes.mdx
@@ -129,7 +129,7 @@ Traefik expects a resource of "Middleware" type named "bouncer", which we will c
 Here is bouncer-middleware.yaml:
   
 ```yaml
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: bouncer


### PR DESCRIPTION
Updating the cited `apiVersion` of the Middleware manifest in the Kubernetes getting started guide to match current traefik standards.

I can also update the guide to use mutual TLS for bouncer authentication if desired, but wasn't sure if that was an intentional choice for the getting started guide.