### PR TITLE
Fix examples in ingress-nginx bouncer

### DIFF
--- a/crowdsec-docs/unversioned/bouncers/ingress-nginx.mdx
+++ b/crowdsec-docs/unversioned/bouncers/ingress-nginx.mdx
@@ -82,7 +82,7 @@ controller:
       ## Appsec configuration, optional.
       ## Remove this section if not using appsec
       - name: APPSEC_URL
-        value: "http://appsec-service.crowdsec.svc.cluster.local:7422" # if using our helm chart, and running the appsec in the "crowdsec" namespace
+        value: "http://crowdsec-appsec-service.crowdsec.svc.cluster.local:7422" # if using our helm chart with "crowdsec" release name, and running the appsec in the "crowdsec" namespace
       - name: APPSEC_FAILURE_ACTION
         value: passthrough # What to do if the appsec is down, optional
       - name: APPSEC_CONNECT_TIMEOUT # connection timeout to the appsec, in ms, optionial
@@ -369,7 +369,7 @@ APPSEC_URL=http://<ip>:<port>
 
 If set, enable appsec mode and forward the request to this endpoint for analysis.
 
-Use `http://appsec-service.crowdsec.svc.cluster.local:7422` if you are using our helm chart to deploy crowdsec in the `crowdsec` namespace
+Use `http://crowdsec-appsec-service.crowdsec.svc.cluster.local:7422` if using our helm chart with `crowdsec` release name, and running the appsec in the `crowdsec` namespace.
 
 ### `APPSEC_FAILURE_ACTION`
 > passthrough | deny

--- a/crowdsec-docs/unversioned/bouncers/ingress-nginx.mdx
+++ b/crowdsec-docs/unversioned/bouncers/ingress-nginx.mdx
@@ -76,23 +76,23 @@ controller:
       - name: SITE_KEY
         value: "<your-captcha-site-key>" # If you want captcha support otherwise remove this ENV VAR
       - name: BAN_TEMPLATE_PATH
-        value: /etc/nginx/lua/plugins/crowdsec/templates/ban.html
+        value: "/etc/nginx/lua/plugins/crowdsec/templates/ban.html"
       - name: CAPTCHA_TEMPLATE_PATH
-        value: /etc/nginx/lua/plugins/crowdsec/templates/captcha.html
+        value: "/etc/nginx/lua/plugins/crowdsec/templates/captcha.html"
       ## Appsec configuration, optional.
       ## Remove this section if not using appsec
       - name: APPSEC_URL
         value: "http://crowdsec-appsec-service.crowdsec.svc.cluster.local:7422" # if using our helm chart with "crowdsec" release name, and running the appsec in the "crowdsec" namespace
       - name: APPSEC_FAILURE_ACTION
-        value: passthrough # What to do if the appsec is down, optional
+        value: "passthrough" # What to do if the appsec is down, optional
       - name: APPSEC_CONNECT_TIMEOUT # connection timeout to the appsec, in ms, optionial
-        value: 100
+        value: "100"
       - name: APPSEC_SEND_TIMEOUT # write timeout to the appsec, in ms, optional
-        value: 100
+        value: "100"
       - name: APPSEC_PROCESS_TIMEOUT # max processing duration of the request, in ms, optional
-        value: 1000
+        value: "1000"
       - name: ALWAYS_SEND_TO_APPSEC
-        value: false # always send requests to the appsec, even if there's a decision against the IP, optional
+        value: "false" # always send requests to the appsec, even if there's a decision against the IP, optional
     command: ['sh', '-c', "sh /docker_start.sh; mkdir -p /lua_plugins/crowdsec/; cp -R /crowdsec/* /lua_plugins/crowdsec/"]
     volumeMounts:
     - name: crowdsec-bouncer-plugin


### PR DESCRIPTION
This PR corrects two issues with the `ingress-nginx` bouncer documentation:

1. `appsec` service name includes release name in the [helm chart](https://github.com/crowdsecurity/helm-charts/blob/3e19a880fcca9015ae5f419a4d9a59f62b91db4d/charts/crowdsec/templates/appsec-service.yaml#L5). This PR will add that to the bouncer documentation
2. Env vars passed to pods [must be strings](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#envvar-v1-core). Upgrading ingress-nginx helm release with current example throws an error:
   `* Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.initContainers.env.value of type string`

   This PR replaces int and bool with strings in the example.