### PR TITLE
WAF: Update traefik plugin configuration

### DIFF
--- a/crowdsec-docs/docs/appsec/quickstart/traefik.mdx
+++ b/crowdsec-docs/docs/appsec/quickstart/traefik.mdx
@@ -157,6 +157,7 @@ http:
     crowdsec:
       plugin:
         bouncer:
+          enabled: true
           crowdsecAppsecEnabled: true
           crowdsecAppsecHost: crowdsec:7422
           crowdsecAppsecFailureBlock: true
@@ -168,6 +169,7 @@ Instead if you define the configuration using labels on the containers you can a
 
 ```yaml
   labels:
+      - "traefik.http.middlewares.crowdsec-bar.plugin.bouncer.enabled=true"
       - "traefik.http.middlewares.crowdsec-bar.plugin.bouncer.crowdsecAppsecEnabled=true"
       - "traefik.http.middlewares.crowdsec-bar.plugin.bouncer.crowdsecAppsecHost=crowdsec:7422"
       - "traefik.http.middlewares.crowdsec-bar.plugin.bouncer.crowdsecLapiKey=privateKey-foo"


### PR DESCRIPTION
I have followed the documentation, on how to set up WAF with CrowdSec and Traefik. It didn't work, so I took a closer look into the plugin documentation and found this.

Since the default for Enabled is false, Enabled has to be set to true

I want to share this small fix with the community.