### PR TITLE
Inform that console management must be active for decision management

### DIFF
--- a/crowdsec-docs/unversioned/console/decisions/decisions_management.md
+++ b/crowdsec-docs/unversioned/console/decisions/decisions_management.md
@@ -4,6 +4,11 @@ title: Decisions Management
 sidebar_position: 1
 ---
 
+:::info
+This feature needs the *console_management* feature activated on your Security Engine
+If your Security Engine was in version >=1.6.9 it should have been done automatically
+Check the instructions to activate it [HERE](/u/console/decisions/decisions_intro)
+:::
 ## Console Management
 
 CrowdSec Local API is able to receive or delete local decisions from the Console.

--- a/crowdsec-docs/unversioned/console/decisions/decisions_management.md
+++ b/crowdsec-docs/unversioned/console/decisions/decisions_management.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 :::info
 This feature needs the *console_management* feature activated on your Security Engine.  
-If your Security Engine was in version >=1.6.9 it should have been done automatically.  
+Activate it to make sure actions from the **decision management** are applied **immediately**
 Check the instructions to activate it [HERE](/u/console/decisions/decisions_intro).
 :::
 ## Console Management

--- a/crowdsec-docs/unversioned/console/decisions/decisions_management.md
+++ b/crowdsec-docs/unversioned/console/decisions/decisions_management.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 :::info
 This feature needs the *console_management* feature activated on your Security Engine.  
-Activate it to make sure actions from the **decision management** are applied **immediately**
+Activate it to make sure actions from the **decision management** are applied **immediately**.  
 Check the instructions to activate it [HERE](/u/console/decisions/decisions_intro).
 :::
 ## Console Management

--- a/crowdsec-docs/unversioned/console/decisions/decisions_management.md
+++ b/crowdsec-docs/unversioned/console/decisions/decisions_management.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 ---
 
 :::info
-This feature needs the *console_management* feature activated on your Security Engine
-If your Security Engine was in version >=1.6.9 it should have been done automatically
-Check the instructions to activate it [HERE](/u/console/decisions/decisions_intro)
+This feature needs the *console_management* feature activated on your Security Engine.  
+If your Security Engine was in version >=1.6.9 it should have been done automatically.  
+Check the instructions to activate it [HERE](/u/console/decisions/decisions_intro).
 :::
 ## Console Management
 


### PR DESCRIPTION
We'll have to move or regroup this somewhere in the future. might evolve too with 1.6.9 release

Info on top of that page: https://pr-776.d1to60jd2gb6y6.amplifyapp.com/u/console/decisions/decisions_management
![image](https://github.com/user-attachments/assets/a45d2cbb-74e7-4e18-b53a-ec400a223eeb)

