### PR TITLE
chore(docs) Loki: Document `no_ready_check`

### DIFF
--- a/crowdsec-docs/docs/log_processor/data_sources/loki.md
+++ b/crowdsec-docs/docs/log_processor/data_sources/loki.md
@@ -70,6 +70,14 @@ The retry interval at startup before giving on loki.
 
 Defaults to `10 seconds`.
 
+### `no_ready_check`
+
+> note : When using Loki hosted in Grafana Cloud, the `/ready` endpoint does not exist, preventing CrowdSec from starting.
+
+To bypass the readiness check. 
+
+Defaults to `false`.
+
 ### `auth`
 
 Login/password authentication for loki, in the format:


### PR DESCRIPTION
Option `no_ready_check` for Loki has been added via https://github.com/crowdsecurity/crowdsec/pull/3317, but it was not documented.