### PR TITLE
Fix code block not closing correctly

### DIFF
--- a/crowdsec-docs/unversioned/bouncers/nginx.mdx
+++ b/crowdsec-docs/unversioned/bouncers/nginx.mdx
@@ -245,7 +245,8 @@ init_worker_by_lua_block {
            ngx.log(ngx.INFO, "Initializing metrics for worker " .. tostring(ngx.worker.id()))
            cs.SetupMetrics()
         end
-}```
+}
+```
 
 The component uses [lua_shared_dict](https://github.com/openresty/lua-nginx-module#lua_shared_dict) to share cache between all workers.
 

--- a/crowdsec-docs/unversioned/bouncers/openresty.mdx
+++ b/crowdsec-docs/unversioned/bouncers/openresty.mdx
@@ -230,7 +230,8 @@ init_worker_by_lua_block {
            ngx.log(ngx.INFO, "Initializing metrics for worker " .. tostring(ngx.worker.id()))
            cs.SetupMetrics()
         end
-}```
+}
+```
 
 
 The component uses [lua_shared_dict](https://github.com/openresty/lua-nginx-module#lua_shared_dict) to share cache between all workers.


### PR DESCRIPTION
I am going through docs and noticed these pages have 2 broken code blocks.

Search for `The component uses` on these pages. Those strings are in code blocks, which should have closed on the previous lines. Pages are here:

https://docs.crowdsec.net/u/bouncers/nginx/
https://docs.crowdsec.net/u/bouncers/openresty/

Here are the fixed versions from the deployment below:

https://pr-906.d1to60jd2gb6y6.amplifyapp.com/u/bouncers/nginx/
https://pr-906.d1to60jd2gb6y6.amplifyapp.com/u/bouncers/openresty/