### PR TITLE
chore: update Docusaurus to 3.9.2

### DIFF
--- a/crowdsec-docs/package-lock.json
+++ b/crowdsec-docs/package-lock.json
@@ -1664,9 +1664,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
-            "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.5.tgz",
+            "integrity": "sha512-20NUVgOrinudkIBzQ2bNxP08YpKprUkRTiRSd2/Z5GOdPImJGkoN4Z7IQe1T5AdyKI1i5L6RBmluqdSzvaq9/w==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-module-imports": "^7.27.1",
@@ -3519,9 +3519,9 @@
             }
         },
         "node_modules/@docusaurus/babel": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.0.tgz",
-            "integrity": "sha512-QcZ+Rey0OvlLK9SPN4/+VWL+ut/tuADVdunA1fmC96fytdYjatdJrcw1koYdp/c+3k6lVYlwg9DDVNDecyLCAA==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.2.tgz",
+            "integrity": "sha512-GEANdi/SgER+L7Japs25YiGil/AUDnFFHaCGPBbundxoWtCkA2lmy7/tFmgED4y1htAy6Oi4wkJEQdGssnw9MA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.9",
@@ -3534,8 +3534,8 @@
                 "@babel/runtime": "^7.25.9",
                 "@babel/runtime-corejs3": "^7.25.9",
                 "@babel/traverse": "^7.25.9",
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
                 "babel-plugin-dynamic-import-node": "^2.3.3",
                 "fs-extra": "^11.1.1",
                 "tslib": "^2.6.0"
@@ -3545,17 +3545,17 @@
             }
         },
         "node_modules/@docusaurus/bundler": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.0.tgz",
-            "integrity": "sha512-HaRLSmiwnJQ3uHBV3rd/BRDM9S/nHAshRk54djRZ+RX9ze4ONuFAovdD5es20ZDj7PRTjo38GVnBtHvuL/SwsQ==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.2.tgz",
+            "integrity": "sha512-ZOVi6GYgTcsZcUzjblpzk3wH1Fya2VNpd5jtHoCCFcJlMQ1EYXZetfAnRHLcyiFeBABaI1ltTYbOBtH/gahGVA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.9",
-                "@docusaurus/babel": "3.9.0",
-                "@docusaurus/cssnano-preset": "3.9.0",
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
+                "@docusaurus/babel": "3.9.2",
+                "@docusaurus/cssnano-preset": "3.9.2",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
                 "babel-loader": "^9.2.1",
                 "clean-css": "^5.3.3",
                 "copy-webpack-plugin": "^11.0.0",
@@ -3588,18 +3588,18 @@
             }
         },
         "node_modules/@docusaurus/core": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.0.tgz",
-            "integrity": "sha512-sEJ4MW/zuh1MfPORCRbSwnW/PjsVmOigWwBU6clcxm221/CNdnI/XqgfBrl2jj/zocSdNoQM8E3IP2W8dygi6g==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
+            "integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/babel": "3.9.0",
-                "@docusaurus/bundler": "3.9.0",
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/mdx-loader": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-common": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/babel": "3.9.2",
+                "@docusaurus/bundler": "3.9.2",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/mdx-loader": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-common": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "boxen": "^6.2.1",
                 "chalk": "^4.1.2",
                 "chokidar": "^3.5.3",
@@ -3649,9 +3649,9 @@
             }
         },
         "node_modules/@docusaurus/cssnano-preset": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.0.tgz",
-            "integrity": "sha512-prCJXUcoJZBlovJzSFkfnfWr1gXd53VZfE+17fIpUWS6Zioc7WE4FPoXPi5ldAGZ8brhXre5xQ8NWDE90XP9yw==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.2.tgz",
+            "integrity": "sha512-8gBKup94aGttRduABsj7bpPFTX7kbwu+xh3K9NMCF5K4bWBqTFYW+REKHF6iBVDHRJ4grZdIPbvkiHd/XNKRMQ==",
             "license": "MIT",
             "dependencies": {
                 "cssnano-preset-advanced": "^6.1.2",
@@ -3664,12 +3664,12 @@
             }
         },
         "node_modules/@docusaurus/faster": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.9.0.tgz",
-            "integrity": "sha512-sb4cxgNtwwI0QihceHhBUYm62NeEFGUIbsGdmRZeJNAZNjKDcjZh8VTWtP/Z4oTIIdVHhWq0QypghyVMgRqOMw==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.9.2.tgz",
+            "integrity": "sha512-DEVIwhbrZZ4ir31X+qQNEQqDWkgCJUV6kiPPAd2MGTY8n5/n0c4B8qA5k1ipF2izwH00JEf0h6Daaut71zzkyw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.9.0",
+                "@docusaurus/types": "3.9.2",
                 "@rspack/core": "^1.5.0",
                 "@swc/core": "^1.7.39",
                 "@swc/html": "^1.13.5",
@@ -3687,9 +3687,9 @@
             }
         },
         "node_modules/@docusaurus/logger": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.0.tgz",
-            "integrity": "sha512-lDtThsocWTF8ZrVF01ltfctA/xgtD/3oXWqEkKIDzF4fCWsWXH7hC4LCqT23xSuxZTIo8N+y02XSPvA/8DLInw==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.2.tgz",
+            "integrity": "sha512-/SVCc57ByARzGSU60c50rMyQlBuMIJCjcsJlkphxY6B0GV4UH3tcA1994N8fFfbJ9kX3jIBe/xg3XP5qBtGDbA==",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2",
@@ -3700,14 +3700,14 @@
             }
         },
         "node_modules/@docusaurus/mdx-loader": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.0.tgz",
-            "integrity": "sha512-9bfJYdkZFE+REwevkT4CYdTJ2f6ydgkbUFylkzTXrNGtBXtx25TRJGdn2cVzm3eVkeWdJrGkG/ypwrIWnbu5UA==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
+            "integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "@mdx-js/mdx": "^3.0.0",
                 "@slorber/remark-comment": "^1.0.0",
                 "escape-html": "^1.0.3",
@@ -3739,12 +3739,12 @@
             }
         },
         "node_modules/@docusaurus/module-type-aliases": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.0.tgz",
-            "integrity": "sha512-0ucYr79FpTCebN+l3ZlKqoW7HbMqSKT8JdsEg6QoUtxD3C7trF6KZiK/X6Yh+xekO1w3zzXYgPcIYTF2DV81tQ==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
+            "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.9.0",
+                "@docusaurus/types": "3.9.2",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
@@ -3758,16 +3758,16 @@
             }
         },
         "node_modules/@docusaurus/plugin-client-redirects": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.9.0.tgz",
-            "integrity": "sha512-uAsItDNp8Cs0sKZaN78Xs9pgaphk4tjpNUkIikQa0Db64umnhYjv+tUYaVqCFeRHo4t0XeEMNpi3Ley5+Z0vBA==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.9.2.tgz",
+            "integrity": "sha512-lUgMArI9vyOYMzLRBUILcg9vcPTCyyI2aiuXq/4npcMVqOr6GfmwtmBYWSbNMlIUM0147smm4WhpXD0KFboffw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-common": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-common": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "eta": "^2.2.0",
                 "fs-extra": "^11.1.1",
                 "lodash": "^4.17.21",
@@ -3782,19 +3782,19 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-blog": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.0.tgz",
-            "integrity": "sha512-XZXJ/rQgi2jT0XWNXOnSKooJgtGHPzkjaBjww6K9PD+YevNMTP9U8Y5sA7cLA5Bwuqrpee4i8NO3tSrjhhDW5w==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.2.tgz",
+            "integrity": "sha512-3I2HXy3L1QcjLJLGAoTvoBnpOwa6DPUa3Q0dMK19UTY9mhPkKQg/DYhAGTiBUKcTR0f08iw7kLPqOhIgdV3eVQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/mdx-loader": "3.9.0",
-                "@docusaurus/theme-common": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-common": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/mdx-loader": "3.9.2",
+                "@docusaurus/theme-common": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-common": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "cheerio": "1.0.0-rc.12",
                 "feed": "^4.2.2",
                 "fs-extra": "^11.1.1",
@@ -3816,20 +3816,20 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-docs": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.0.tgz",
-            "integrity": "sha512-PP+iDJg+lj4cn/7GbbmiguaQ8OX08YxnzQ17KqRC4ufJm11jdyXD33wA7vVtbeG/BkkgkiB/K7YyPHCPwmfVhg==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
+            "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/mdx-loader": "3.9.0",
-                "@docusaurus/module-type-aliases": "3.9.0",
-                "@docusaurus/theme-common": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-common": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/mdx-loader": "3.9.2",
+                "@docusaurus/module-type-aliases": "3.9.2",
+                "@docusaurus/theme-common": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-common": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "@types/react-router-config": "^5.0.7",
                 "combine-promises": "^1.1.0",
                 "fs-extra": "^11.1.1",
@@ -3849,16 +3849,16 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-pages": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.0.tgz",
-            "integrity": "sha512-ngetCpAZuivlaHC0l8a5KoK6PQWGuZ8742VwK7dbXeIW0Y70P4xwuocBdsCIQ9J6nB9rlTXRYMpNVyYyCpD7/Q==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.2.tgz",
+            "integrity": "sha512-s4849w/p4noXUrGpPUF0BPqIAfdAe76BLaRGAGKZ1gTDNiGxGcpsLcwJ9OTi1/V8A+AzvsmI9pkjie2zjIQZKA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/mdx-loader": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/mdx-loader": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "fs-extra": "^11.1.1",
                 "tslib": "^2.6.0",
                 "webpack": "^5.88.1"
@@ -3872,15 +3872,15 @@
             }
         },
         "node_modules/@docusaurus/plugin-css-cascade-layers": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.0.tgz",
-            "integrity": "sha512-giPTCjEzeaamMn8EHY/oDvsPDxF5ei1/q5lPUFQLldbc65jFQ1k6pPwKjtOznYy3TSfClCF1F1DNpYWIx7B5LA==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.2.tgz",
+            "integrity": "sha512-w1s3+Ss+eOQbscGM4cfIFBlVg/QKxyYgj26k5AnakuHkKxH6004ZtuLe5awMBotIYF2bbGDoDhpgQ4r/kcj4rQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3888,14 +3888,14 @@
             }
         },
         "node_modules/@docusaurus/plugin-debug": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.0.tgz",
-            "integrity": "sha512-DuFOZya+bcrYiL54qBEn2rdKuoWWNyOV5IoHI2MURLzwuYaKu/J9Gi618XUsj3N3qvqG2uxWQiXZcs9ecfMadA==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.2.tgz",
+            "integrity": "sha512-j7a5hWuAFxyQAkilZwhsQ/b3T7FfHZ+0dub6j/GxKNFJp2h9qk/P1Bp7vrGASnvA9KNQBBL1ZXTe7jlh4VdPdA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
                 "fs-extra": "^11.1.1",
                 "react-json-view-lite": "^2.3.0",
                 "tslib": "^2.6.0"
@@ -3909,14 +3909,14 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-analytics": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.0.tgz",
-            "integrity": "sha512-mUXvpasTDR2pXdnkkhGxEgB9frVAvLGc+T3fp6SGT2F+YoEQtjcmz9D43zubQawLn+W1KEhoj+vPusYe+HAl+A==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.2.tgz",
+            "integrity": "sha512-mAwwQJ1Us9jL/lVjXtErXto4p4/iaLlweC54yDUK1a97WfkC6Z2k5/769JsFgwOwOP+n5mUQGACXOEQ0XDuVUw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3928,14 +3928,14 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-gtag": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.0.tgz",
-            "integrity": "sha512-L4tCKYnmcyLV6VQs7XWQ3r7YSllagAU2GylZzdvz7NRMcXE12uSW5MCC2aSltbk09MYlqrYv1Ntp+ESsMvptYw==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.2.tgz",
+            "integrity": "sha512-YJ4lDCphabBtw19ooSlc1MnxtYGpjFV9rEdzjLsUnBCeis2djUyCozZaFhCg6NGEwOn7HDDyMh0yzcdRpnuIvA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "@types/gtag.js": "^0.0.12",
                 "tslib": "^2.6.0"
             },
@@ -3948,14 +3948,14 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-tag-manager": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.0.tgz",
-            "integrity": "sha512-+jWO3tkrvsMUKQ69KTIj9ZBf8sKY5kodLcP4yIaEkPzfWq9IEpE+ekQCtFWlrAmkJUtSxbjHK6HNZZkUNwwq7w==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.2.tgz",
+            "integrity": "sha512-LJtIrkZN/tuHD8NqDAW1Tnw0ekOwRTfobWPsdO15YxcicBo2ykKF0/D6n0vVBfd3srwr9Z6rzrIWYrMzBGrvNw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3967,17 +3967,17 @@
             }
         },
         "node_modules/@docusaurus/plugin-sitemap": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.0.tgz",
-            "integrity": "sha512-QOyLooWuF+On4q2RDGVZtKY0tlfdZwD9e/p7g1sJLUfOwN518V2Bo+kZtU82Or42SCKjyJ0lhSqAUOZfbeFhFw==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.2.tgz",
+            "integrity": "sha512-WLh7ymgDXjG8oPoM/T4/zUP7KcSuFYRZAUTl8vR6VzYkfc18GBM4xLhcT+AKOwun6kBivYKUJf+vlqYJkm+RHw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-common": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-common": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "fs-extra": "^11.1.1",
                 "sitemap": "^7.1.1",
                 "tslib": "^2.6.0"
@@ -3991,15 +3991,15 @@
             }
         },
         "node_modules/@docusaurus/plugin-svgr": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.0.tgz",
-            "integrity": "sha512-pUZIfnhFtAYDmDwimFiBY+sxNUigyJnKbCwI9pTiXr3uGp43CsSsN8gwl/i8jBmqfsZzvNnGZNxc75wy9v6RXA==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.2.tgz",
+            "integrity": "sha512-n+1DE+5b3Lnf27TgVU5jM1d4x5tUh2oW5LTsBxJX4PsAPV0JGcmI6p3yLYtEY0LRVEIJh+8RsdQmRE66wSV8mw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "@svgr/core": "8.1.0",
                 "@svgr/webpack": "^8.1.0",
                 "tslib": "^2.6.0",
@@ -4014,26 +4014,26 @@
             }
         },
         "node_modules/@docusaurus/preset-classic": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.0.tgz",
-            "integrity": "sha512-nLoiDxf8bDNNxDSZ28+pFfSfT+QRi08Pn2K0zIvbjkM/X/otMs4ho0K8+2FpoLOoGApifaSuNfJXpGYnQV3rGA==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.2.tgz",
+            "integrity": "sha512-IgyYO2Gvaigi21LuDIe+nvmN/dfGXAiMcV/murFqcpjnZc7jxFAxW+9LEjdPt61uZLxG4ByW/oUmX/DDK9t/8w==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/plugin-content-blog": "3.9.0",
-                "@docusaurus/plugin-content-docs": "3.9.0",
-                "@docusaurus/plugin-content-pages": "3.9.0",
-                "@docusaurus/plugin-css-cascade-layers": "3.9.0",
-                "@docusaurus/plugin-debug": "3.9.0",
-                "@docusaurus/plugin-google-analytics": "3.9.0",
-                "@docusaurus/plugin-google-gtag": "3.9.0",
-                "@docusaurus/plugin-google-tag-manager": "3.9.0",
-                "@docusaurus/plugin-sitemap": "3.9.0",
-                "@docusaurus/plugin-svgr": "3.9.0",
-                "@docusaurus/theme-classic": "3.9.0",
-                "@docusaurus/theme-common": "3.9.0",
-                "@docusaurus/theme-search-algolia": "3.9.0",
-                "@docusaurus/types": "3.9.0"
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/plugin-content-blog": "3.9.2",
+                "@docusaurus/plugin-content-docs": "3.9.2",
+                "@docusaurus/plugin-content-pages": "3.9.2",
+                "@docusaurus/plugin-css-cascade-layers": "3.9.2",
+                "@docusaurus/plugin-debug": "3.9.2",
+                "@docusaurus/plugin-google-analytics": "3.9.2",
+                "@docusaurus/plugin-google-gtag": "3.9.2",
+                "@docusaurus/plugin-google-tag-manager": "3.9.2",
+                "@docusaurus/plugin-sitemap": "3.9.2",
+                "@docusaurus/plugin-svgr": "3.9.2",
+                "@docusaurus/theme-classic": "3.9.2",
+                "@docusaurus/theme-common": "3.9.2",
+                "@docusaurus/theme-search-algolia": "3.9.2",
+                "@docusaurus/types": "3.9.2"
             },
             "engines": {
                 "node": ">=20.0"
@@ -4044,24 +4044,24 @@
             }
         },
         "node_modules/@docusaurus/theme-classic": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.0.tgz",
-            "integrity": "sha512-RToUIabJOyX41nMIxkFn8LPeA+uHgySzyd6Ak/gsINqWHHTLDMoYPxBUmNm3S+okcfuMI54kNYvD6TY+6TIYDA==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.2.tgz",
+            "integrity": "sha512-IGUsArG5hhekXd7RDb11v94ycpJpFdJPkLnt10fFQWOVxAtq5/D7hT6lzc2fhyQKaaCE62qVajOMKL7OiAFAIA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/mdx-loader": "3.9.0",
-                "@docusaurus/module-type-aliases": "3.9.0",
-                "@docusaurus/plugin-content-blog": "3.9.0",
-                "@docusaurus/plugin-content-docs": "3.9.0",
-                "@docusaurus/plugin-content-pages": "3.9.0",
-                "@docusaurus/theme-common": "3.9.0",
-                "@docusaurus/theme-translations": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-common": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/mdx-loader": "3.9.2",
+                "@docusaurus/module-type-aliases": "3.9.2",
+                "@docusaurus/plugin-content-blog": "3.9.2",
+                "@docusaurus/plugin-content-docs": "3.9.2",
+                "@docusaurus/plugin-content-pages": "3.9.2",
+                "@docusaurus/theme-common": "3.9.2",
+                "@docusaurus/theme-translations": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-common": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "@mdx-js/react": "^3.0.0",
                 "clsx": "^2.0.0",
                 "infima": "0.2.0-alpha.45",
@@ -4084,15 +4084,15 @@
             }
         },
         "node_modules/@docusaurus/theme-common": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.0.tgz",
-            "integrity": "sha512-pqNoQgttIpk7Ndm6N8OGbhi+1wBIQXQPYM7bPf1HDraXfvVpOzhcDty1yyK4coPWl0M7NxednZvKw4atfQ70Ew==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
+            "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/mdx-loader": "3.9.0",
-                "@docusaurus/module-type-aliases": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-common": "3.9.0",
+                "@docusaurus/mdx-loader": "3.9.2",
+                "@docusaurus/module-type-aliases": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-common": "3.9.2",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
@@ -4112,19 +4112,19 @@
             }
         },
         "node_modules/@docusaurus/theme-search-algolia": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.0.tgz",
-            "integrity": "sha512-nbY7ZJVA10kTiBLJtscxK1aECeYvYFz+Sno9PkCE9KeFXqRDr6omtNmLVkbvyl4b6xgz+6yOIBdO/idLPVDpWg==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.2.tgz",
+            "integrity": "sha512-GBDSFNwjnh5/LdkxCKQHkgO2pIMX1447BxYUBG2wBiajS21uj64a+gH/qlbQjDLxmGrbrllBrtJkUHxIsiwRnw==",
             "license": "MIT",
             "dependencies": {
                 "@docsearch/react": "^3.9.0 || ^4.1.0",
-                "@docusaurus/core": "3.9.0",
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/plugin-content-docs": "3.9.0",
-                "@docusaurus/theme-common": "3.9.0",
-                "@docusaurus/theme-translations": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-validation": "3.9.0",
+                "@docusaurus/core": "3.9.2",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/plugin-content-docs": "3.9.2",
+                "@docusaurus/theme-common": "3.9.2",
+                "@docusaurus/theme-translations": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-validation": "3.9.2",
                 "algoliasearch": "^5.37.0",
                 "algoliasearch-helper": "^3.26.0",
                 "clsx": "^2.0.0",
@@ -4143,9 +4143,9 @@
             }
         },
         "node_modules/@docusaurus/theme-translations": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.0.tgz",
-            "integrity": "sha512-4HUELBsE+rhtlnR1MsaNB9nJXPFZANeDQa5If1GfFVlis5mWUfdmXmbGangR7PfpK2tc56UETMtzjKrX5L5UWw==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.2.tgz",
+            "integrity": "sha512-vIryvpP18ON9T9rjgMRFLr2xJVDpw1rtagEGf8Ccce4CkTrvM/fRB8N2nyWYOW5u3DdjkwKw5fBa+3tbn9P4PA==",
             "license": "MIT",
             "dependencies": {
                 "fs-extra": "^11.1.1",
@@ -4156,16 +4156,16 @@
             }
         },
         "node_modules/@docusaurus/tsconfig": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.9.0.tgz",
-            "integrity": "sha512-DPD1NcEAqBov2e2Rgwy/oNuExbWzU/eGc+DEAxl8tttfQ+xxN6iFXNMCzBuMeAvMC8OwUO+i9mZHYFP95903DA==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.9.2.tgz",
+            "integrity": "sha512-j6/Fp4Rlpxsc632cnRnl5HpOWeb6ZKssDj6/XzzAzVGXXfm9Eptx3rxCC+fDzySn9fHTS+CWJjPineCR1bB5WQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@docusaurus/types": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-            "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
             "license": "MIT",
             "dependencies": {
                 "@mdx-js/mdx": "^3.0.0",
@@ -4199,14 +4199,14 @@
             }
         },
         "node_modules/@docusaurus/utils": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.0.tgz",
-            "integrity": "sha512-wpVRQbDhXxqbb1llhkpu++aD4UdHHQ5M7J8DmJELDphlwmpI44TdS5elQZOsjzPfGyITZyQLekcDXjyteJ0/bw==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.2.tgz",
+            "integrity": "sha512-lBSBiRruFurFKXr5Hbsl2thmGweAPmddhF3jb99U4EMDA5L+e5Y1rAkOS07Nvrup7HUMBDrCV45meaxZnt28nQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/types": "3.9.0",
-                "@docusaurus/utils-common": "3.9.0",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/types": "3.9.2",
+                "@docusaurus/utils-common": "3.9.2",
                 "escape-string-regexp": "^4.0.0",
                 "execa": "5.1.1",
                 "file-loader": "^6.2.0",
@@ -4231,12 +4231,12 @@
             }
         },
         "node_modules/@docusaurus/utils-common": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.0.tgz",
-            "integrity": "sha512-zpmzRn2mniMnrx8ZEYyyDsr0/7EksVgUXL9IuODp0DSK+R19nDGCY7w2NaMGRmGnrQQKsT3t0NDZzBk0V6N9Iw==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.2.tgz",
+            "integrity": "sha512-I53UC1QctruA6SWLvbjbhCpAw7+X7PePoe5pYcwTOEXD/PxeP8LnECAhTHHwWCblyUX5bMi4QLRkxvyZ+IT8Aw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.9.0",
+                "@docusaurus/types": "3.9.2",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -4244,14 +4244,14 @@
             }
         },
         "node_modules/@docusaurus/utils-validation": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.0.tgz",
-            "integrity": "sha512-xpVLdFPpsE5dYuE7hOtghccCrRWRhM6tUQ4YpfSy5snCDWgROITG5Mj22fGstd/HBqTzKD8NFs7qPPs42qjgWg==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
+            "integrity": "sha512-l7yk3X5VnNmATbwijJkexdhulNsQaNDwoagiwujXoxFbWLcxHQqNQ+c/IAlzrfMMOfa/8xSBZ7KEKDesE/2J7A==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.9.0",
-                "@docusaurus/utils": "3.9.0",
-                "@docusaurus/utils-common": "3.9.0",
+                "@docusaurus/logger": "3.9.2",
+                "@docusaurus/utils": "3.9.2",
+                "@docusaurus/utils-common": "3.9.2",
                 "fs-extra": "^11.2.0",
                 "joi": "^17.9.2",
                 "js-yaml": "^4.1.0",
@@ -7352,9 +7352,9 @@
             }
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.33",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+            "version": "17.0.34",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.34.tgz",
+            "integrity": "sha512-KExbHVa92aJpw9WDQvzBaGVE2/Pz+pLZQloT2hjL8IqsZnV62rlPOYvNnLmf/L2dyllfVUOVBj64M0z/46eR2A==",
             "license": "MIT",
             "dependencies": {
                 "@types/yargs-parser": "*"
@@ -9013,9 +9013,9 @@
             }
         },
         "node_modules/core-js-pure": {
-            "version": "3.45.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.1.tgz",
-            "integrity": "sha512-OHnWFKgTUshEU8MK+lOs1H8kC8GkTi9Z1tvNkxrCcw9wl3MJIO7q2ld77wjWn4/xuGrVu2X+nME1iIIPBSdyEQ==",
+            "version": "3.46.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.46.0.tgz",
+            "integrity": "sha512-NMCW30bHNofuhwLhYPt66OLOKTMbOhgTTatKVbaQC3KRHpTCiRIBYvtshr+NBYSnBxwAFhjW/RfJ0XbIjS16rw==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {
@@ -19404,9 +19404,9 @@
             }
         },
         "node_modules/std-env": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-            "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
             "license": "MIT"
         },
         "node_modules/string_decoder": {


### PR DESCRIPTION
Update all Docusaurus packages from 3.9.0 to 3.9.2 (patch release)
- @docusaurus/core
- @docusaurus/faster
- @docusaurus/preset-classic
- @docusaurus/plugin-client-redirects
- @docusaurus/theme-common
- @docusaurus/theme-search-algolia
- @docusaurus/module-type-aliases
- @docusaurus/tsconfig
- @docusaurus/types