### PR TITLE
chore: update TypeScript to 5.9.3

### DIFF
--- a/crowdsec-docs/package-lock.json
+++ b/crowdsec-docs/package-lock.json
@@ -20101,9 +20101,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {


### PR DESCRIPTION
Update typescript from 5.8.3 to 5.9.3 (minor release) Includes compiler improvements and bug fixes.