### PR TITLE
chore: update tailwindcss to 3.4.18

### DIFF
--- a/crowdsec-docs/package-lock.json
+++ b/crowdsec-docs/package-lock.json
@@ -19738,9 +19738,9 @@
             }
         },
         "node_modules/tailwindcss": {
-            "version": "3.4.17",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-            "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+            "version": "3.4.18",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
+            "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
             "license": "MIT",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
@@ -19751,7 +19751,7 @@
                 "fast-glob": "^3.3.2",
                 "glob-parent": "^6.0.2",
                 "is-glob": "^4.0.3",
-                "jiti": "^1.21.6",
+                "jiti": "^1.21.7",
                 "lilconfig": "^3.1.3",
                 "micromatch": "^4.0.8",
                 "normalize-path": "^3.0.0",
@@ -19760,7 +19760,7 @@
                 "postcss": "^8.4.47",
                 "postcss-import": "^15.1.0",
                 "postcss-js": "^4.0.1",
-                "postcss-load-config": "^4.0.2",
+                "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
                 "postcss-nested": "^6.2.0",
                 "postcss-selector-parser": "^6.1.2",
                 "resolve": "^1.22.8",


### PR DESCRIPTION
Update tailwindcss from 3.4.17 to 3.4.18 (patch release) Staying on v3.x for compatibility.