### PR TITLE
chore: update lucide-react to 0.552.0

### DIFF
--- a/crowdsec-docs/package-lock.json
+++ b/crowdsec-docs/package-lock.json
@@ -29,7 +29,7 @@
                 "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
                 "docusaurus-plugin-zooming": "^1.0.0",
-                "lucide-react": "^0.441.0",
+                "lucide-react": "^0.552.0",
                 "material-react-table": "^2.0.2",
                 "prism-react-renderer": "^2.4.0",
                 "react": "^18.3.1",
@@ -12841,12 +12841,12 @@
             }
         },
         "node_modules/lucide-react": {
-            "version": "0.441.0",
-            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.441.0.tgz",
-            "integrity": "sha512-0vfExYtvSDhkC2lqg0zYVW1Uu9GsI4knuV9GP9by5z0Xhc4Zi5RejTxfz9LsjRmCyWVzHCJvxGKZWcRyvQCWVg==",
+            "version": "0.552.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.552.0.tgz",
+            "integrity": "sha512-g9WCjmfwqbexSnZE+2cl21PCfXOcqnGeWeMTNAOGEfpPbm/ZF4YIq77Z8qWrxbu660EKuLB4nSLggoKnCb+isw==",
             "license": "ISC",
             "peerDependencies": {
-                "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+                "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/markdown-extensions": {

--- a/crowdsec-docs/package.json
+++ b/crowdsec-docs/package.json
@@ -38,7 +38,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "docusaurus-plugin-zooming": "^1.0.0",
-        "lucide-react": "^0.441.0",
+        "lucide-react": "^0.552.0",
         "material-react-table": "^2.0.2",
         "prism-react-renderer": "^2.4.0",
         "react": "^18.3.1",


### PR DESCRIPTION
Update lucide-react from 0.441.0 to 0.552.0
New icons and improvements to the icon library.