### PR TITLE
Add NPMplus AppSec quickstart guide

### DIFF
--- a/crowdsec-docs/docs/appsec/quickstart/npmplus.mdx
+++ b/crowdsec-docs/docs/appsec/quickstart/npmplus.mdx
@@ -1,0 +1,278 @@
+---
+id: npmplus
+title: QuickStart - NPMplus
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import UnderlineTooltip from '@site/src/components/underline-tooltip';
+
+# CrowdSec WAF QuickStart for NPMplus
+
+## Objectives
+
+The goal of this quickstart is to set up the [AppSec Component](/appsec/intro.md#introduction) to safeguard web applications running on [NPMplus](https://github.com/ZoeyVid/NPMplus), an enhanced version of Nginx Proxy Manager.
+
+We'll deploy a [set of rules](https://app.crowdsec.net/hub/author/crowdsecurity/collections/appsec-virtual-patching) designed to block [well-known attacks](https://app.crowdsec.net/hub/author/crowdsecurity/collections/appsec-generic-rules) and [currently exploited vulnerabilities](https://app.crowdsec.net/hub/author/crowdsecurity/collections/appsec-virtual-patching).
+
+Additionally, we'll show how to monitor these alerts through the [console](https://app.crowdsec.net/).
+
+## Pre-requisites
+
+1. If you're new to the [AppSec Component](/appsec/intro.md#introduction) or **W**eb **A**pplication **F**irewalls, start with the [Introduction](/appsec/intro.md#introduction) for a better understanding.
+
+2. It's assumed that you have:
+   - **Docker and Docker Compose** installed and ready
+   - **Ports available**: 80/TCP, 443/TCP, 443/UDP (exposed to internet), 81/TCP (admin interface, can be internal)
+   - A text editor (e.g., nano, vim) and a way to download files (e.g., curl)
+
+:::info
+NPMplus is an enhanced version of Nginx Proxy Manager that provides additional security, performance optimizations, and advanced features for reverse proxy and web server management. It includes built-in support for CrowdSec integration.
+:::
+
+## AppSec Component Setup
+
+### Collection installation
+
+To begin setting up the AppSec Component, the initial step is to install a relevant set of rules.
+
+We will utilize the [`crowdsecurity/appsec-virtual-patching`](https://app.crowdsec.net/hub/author/crowdsecurity/collections/appsec-virtual-patching) collection, which offers a wide range of rules aimed at identifying and preventing the exploitation of known vulnerabilities.
+
+This <UnderlineTooltip tooltip="Collections are bundle of parsers, scenarios, postoverflows that form a coherent package.">collection</UnderlineTooltip> is regularly updated to include protection against newly discovered vulnerabilities. Upon installation, it receives automatic daily updates to ensure your protection is always current.
+
+Furthermore we also install the [`crowdsecurity/appsec-generic-rules`](https://app.crowdsec.net/hub/author/crowdsecurity/collections/appsec-generic-rules) collection. This collection contains detection scenarios for generic attack vectors. It provides some protection in cases where specific scenarios for vulnerabilities do not exist (yet).
+
+:::info
+You can always view the content of a [collection on the hub](https://app.crowdsec.net/hub/author/crowdsecurity/collections/appsec-virtual-patching)
+:::
+
+### Setup the Acquisition
+
+NPMplus provides a Docker Compose file that includes both NPMplus and CrowdSec services. We need to configure the acquisition for AppSec and NPMplus log parsing.
+
+**Steps:**
+
+1. Download the compose.yaml file:
+
+```bash
+curl -L https://raw.githubusercontent.com/ZoeyVid/NPMplus/refs/heads/develop/compose.yaml -o compose.yaml
+```
+
+2. Edit the `compose.yaml` file with your preferred text editor:
+
+   - **For the NPMplus service**: Set the environment variables:
+     - `TZ`: Your timezone (e.g., `TZ=Europe/Berlin`)
+     - `ACME_EMAIL`: Your email address for Let's Encrypt (e.g., `ACME_EMAIL=admin@example.org`)
+     - `LOGROTATE`: Set to `true` (uncomment this line). This is required for CrowdSec to parse NPMplus logs.
+
+   - **For the CrowdSec service**: Uncomment the `crowdsec` service block. Make sure to keep the `openappsec` line commented (note: `appsec` and `openappsec` are different things).
+
+3. Create the acquisition directory and configuration file:
+
+   The exact path depends on how volumes are mounted in your `compose.yaml`. Typically, you'll need to create the file in the location where CrowdSec's configuration is persisted. If the compose file mounts `/opt/crowdsec` or `/etc/crowdsec` from the host, create the directory and file there:
+
+```bash
+# Adjust the path based on your Docker volume mounts
+mkdir -p /opt/crowdsec/conf/acquis.d
+```
+
+   Alternatively, if you're using a different volume mount path, adjust accordingly. You can also create the file directly inside the container:
+
+```bash
+docker exec -it crowdsec mkdir -p /etc/crowdsec/acquis.d
+```
+
+4. Create the acquisition configuration file `/opt/crowdsec/conf/acquis.d/npmplus.yaml` (or `/etc/crowdsec/acquis.d/npmplus.yaml` if using the container path) with the following content:
+
+```yaml title="/opt/crowdsec/conf/acquis.d/npmplus.yaml"
+filenames:
+  - /opt/npmplus/nginx/*.log
+labels:
+  type: npmplus
+---
+filenames:
+  - /opt/npmplus/nginx/*.log
+labels:
+  type: modsecurity
+---
+listen_addr: 0.0.0.0:7422
+appsec_config: crowdsecurity/appsec-default
+name: appsec
+source: appsec
+labels:
+  type: appsec
+```
+
+:::info
+You can find the newest version of the `npmplus.yaml` acquisition file [here](https://github.com/ZoeyVid/NPMplus).
+:::
+
+**Configuration explained:**
+
+- The first two sections configure log parsing for NPMplus logs
+- The third section configures the AppSec Component:
+  - `listen_addr: 0.0.0.0:7422`: The AppSec Component listens on all interfaces on port 7422 (needed for Docker networking)
+  - `appsec_config`: Uses the default configuration from the installed collections
+  - `source: appsec`: Identifies this as an AppSec data source
+
+### Running NPMplus and CrowdSec
+
+Start the services using Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+### Install AppSec Collections
+
+After the containers have started, install the required AppSec collections inside the CrowdSec container:
+
+```bash
+docker exec crowdsec cscli collections install crowdsecurity/appsec-virtual-patching crowdsecurity/appsec-generic-rules
+```
+
+This command installs the following items:
+- The [*AppSec Rules*](/appsec/rules_syntax.md) contain the definition of malevolent requests to be matched and stopped
+- The [*AppSec Configuration*](/appsec/configuration.md#appsec-configuration-files) links together a set of rules to provide a coherent set
+- The <UnderlineTooltip tooltip="YAML files that extract relevant data from logs, such as IP addresses, timestamps, or request paths.">CrowdSec Parser</UnderlineTooltip> and <UnderlineTooltip tooltip="Behavioral rules written in a domain-specific language that define what malicious activity looks like, such as multiple failed logins in a short time.">CrowdSec Scenario(s)</UnderlineTooltip> are used to detect and remediate persistent attacks
+
+After installing the collections, restart the CrowdSec container to load the new configuration:
+
+```bash
+docker restart crowdsec
+```
+
+:::warning Important
+After starting NPMplus, wait about a minute, then check the logs to retrieve the initial admin password:
+
+```bash
+docker logs npmplus
+```
+
+**Save this password** - you'll need it to log into the NPMplus admin interface.
+:::
+
+## Remediation Component Setup
+
+Now we need to configure NPMplus to function as a Remediation Component for the Security Engine and enable the AppSec Component.
+
+### Generate API Key
+
+Generate an API key for NPMplus:
+
+```bash
+docker exec crowdsec cscli bouncers add npmplus -o raw
+```
+
+Copy the output API key - you'll need it in the next step.
+
+### Configure NPMplus
+
+Edit the NPMplus CrowdSec configuration file:
+
+```bash
+# The file location may vary depending on your Docker setup
+# Typically it's at: /opt/npmplus/crowdsec/crowdsec.conf
+```
+
+In this file, you need to:
+
+1. Set `ENABLED=true` to enable the CrowdSec integration
+2. Set `API_KEY` to the key you generated in the previous step
+
+The configuration file should look similar to:
+
+```ini
+ENABLED=true
+API_KEY=your-api-key-here
+```
+
+### Restart NPMplus
+
+Restart the NPMplus container to apply the changes:
+
+```bash
+docker restart npmplus
+```
+
+### Verify Connection
+
+Check the Docker logs to confirm NPMplus is connected to CrowdSec:
+
+```bash
+docker logs npmplus
+```
+
+You should see lines mentioning that NPMplus is connected to CrowdSec.
+
+## Testing the AppSec Component + Remediation Component
+
+:::note
+We're assuming the web server is accessible. Please adjust your testing accordingly.
+:::
+
+If you try to access `http://localhost/.env` (or your server's IP address) from a browser, your request will be blocked, resulting in the display of the following HTML page:
+
+![appsec-denied](/img/appsec_denied.png)
+
+We can also look at the metrics from `cscli metrics show appsec` - it will display:
+- the number of requests processed by the AppSec Component
+- Individual rule matches
+
+<details>
+  <summary>Example Output</summary>
+
+```bash title="docker exec crowdsec cscli metrics show appsec"
+Appsec Metrics:
+╭─────────────────┬───────────┬─────────╮
+│  Appsec Engine  │ Processed │ Blocked │
+├─────────────────┼───────────┼─────────┤
+│ 0.0.0.0:7422/   │ 2         │ 1       │
+╰─────────────────┴───────────┴─────────╯
+
+Appsec '0.0.0.0:7422/' Rules Metrics:
+╭─────────────────────────────────┬───────────╮
+│             Rule ID             │ Triggered │
+├─────────────────────────────────┼─────────┤
+│ crowdsecurity/vpatch-env-access │ 1         │
+╰─────────────────────────────────┴───────────╯
+```
+
+You can test and investigate further with [Stack Health-Check](/u/getting_started/health_check) and [Appsec Troubleshooting guide](/appsec/troubleshooting)
+
+</details>
+
+### Explanation
+
+What happened in the test that we just did is:
+
+1. We did a request (`localhost/.env`) to our web server
+2. Thanks to the NPMplus Remediation Component configuration, the request was forwarded to `http://crowdsec:7422` (or the appropriate Docker network address)
+3. Our AppSec Component, listening on `0.0.0.0:7422` analyzed the request
+4. The request matches the [AppSec rule to detect .env access](https://app.crowdsec.net/hub/author/crowdsecurity/appsec-rules/vpatch-env-access)
+5. The AppSec Component thus answered with [HTTP 403](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) to the Remediation Component, indicating that the request must be blocked
+6. The web server then presented us with the default "request blocked" page.
+
+## Integration with the console
+
+If you haven't yet, follow the guide about [how to enroll your Security Engine in the console](/u/getting_started/post_installation/console).
+
+Once done, all your alerts, including the ones generated by the AppSec Component, are going to appear in the console:
+
+![appsec-console](/img/appsec_console.png)
+
+## Next steps
+
+You are now running the AppSec Component on your CrowdSec Security Engine with NPMplus, congrats!
+
+:::info
+You can now log into the NPMplus admin interface at `https://<ip-of-the-server>:81` using the email address you configured (`ACME_EMAIL`) and the password you saved earlier. You should be prompted to change these credentials on first login.
+:::
+
+As the next steps, you can:
+- [Explore the hub](https://hub.crowdsec.net) to find more rules for your use case
+- Look at the [Rules syntax](/appsec/rules_syntax.md) and [creation process](/appsec/create_rules.md) to create your own and contribute
+- Take a look at [the benchmarks](/appsec/benchmark.md)
+- Use the same steps to set up all your hosts if you want
+

--- a/crowdsec-docs/sidebars.ts
+++ b/crowdsec-docs/sidebars.ts
@@ -730,6 +730,7 @@ const sidebarsConfig: SidebarConfig = {
 				{ type: "doc", id: "appsec/quickstart/general_setup" },
 				{ type: "doc", id: "appsec/quickstart/nginx-ingress" },
 				{ type: "doc", id: "appsec/quickstart/nginxopenresty" },
+				{ type: "doc", id: "appsec/quickstart/npmplus" },
 				{ type: "doc", id: "appsec/quickstart/traefik" },
 				{ type: "doc", id: "appsec/quickstart/wordpress" },
 			],


### PR DESCRIPTION
- Created new getting started guide for NPMplus with AppSec Component
- Added guide to AppSec sidebar under Installation section
- Follows same structure as other AppSec quickstart guides
- Includes Docker Compose setup, collection installation, and remediation component configuration