### PR TITLE
security: update React to 19.2.1 to fix CVE

### DIFF
--- a/crowdsec-docs/package-lock.json
+++ b/crowdsec-docs/package-lock.json
@@ -32,8 +32,8 @@
                 "lucide-react": "^0.552.0",
                 "material-react-table": "^3.2.1",
                 "prism-react-renderer": "^2.4.1",
-                "react": "^19.2.0",
-                "react-dom": "^19.2.0",
+                "react": "^19.2.1",
+                "react-dom": "^19.2.1",
                 "tailwind-merge": "^3.3.1",
                 "tailwindcss-animate": "^1.0.7"
             },
@@ -17125,24 +17125,24 @@
             }
         },
         "node_modules/react": {
-            "version": "19.2.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-            "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+            "version": "19.2.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
+            "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react-dom": {
-            "version": "19.2.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-            "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+            "version": "19.2.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+            "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.2.0"
+                "react": "^19.2.1"
             }
         },
         "node_modules/react-fast-compare": {

--- a/crowdsec-docs/package.json
+++ b/crowdsec-docs/package.json
@@ -41,8 +41,8 @@
         "lucide-react": "^0.552.0",
         "material-react-table": "^3.2.1",
         "prism-react-renderer": "^2.4.1",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
+        "react": "^19.2.1",
+        "react-dom": "^19.2.1",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7"
     },


### PR DESCRIPTION
Even though docusarus doesnt use RSC .... yet, best to update anyways