### PR TITLE
feat(bouncers-mtls): mTLS options on nginx, ingress-nginx and OpenResty bouncers

### DIFF
--- a/crowdsec-docs/unversioned/bouncers/ingress-nginx.mdx
+++ b/crowdsec-docs/unversioned/bouncers/ingress-nginx.mdx
@@ -28,7 +28,7 @@ import RemediationSupportBadges from "@site/src/components/remediation-support-b
   &#128172; <a href="https://discourse.crowdsec.net">Discourse </a>
 </p>
 
-<RemediationSupportBadges Mode Appsec Metrics />
+<RemediationSupportBadges Mode Appsec Metrics MTLS />
 
 A lua Remediation Component for Ingress Nginx Controller.
 
@@ -226,6 +226,36 @@ API_URL=http://<ip>:<port>
 ```
 
 CrowdSec local API URL.
+
+### `USE_TLS_AUTH`
+
+> boolean
+
+```bash
+USE_TLS_AUTH=false # default
+```
+
+Enable mutual TLS (mTLS) authentication for secure communication with CrowdSec Local API. When enabled, the bouncer will use client certificates for authentication instead of API keys.
+
+### `TLS_CLIENT_CERT`
+
+> string (path to file)
+
+```bash
+TLS_CLIENT_CERT=<path_to_cert>
+```
+
+Path to the client certificate file for mTLS authentication. This option is only used when `USE_TLS_AUTH` is set to `true`.
+
+### `TLS_CLIENT_KEY`
+
+> string (path to file)
+
+```bash
+TLS_CLIENT_KEY=<path_to_key>
+```
+
+Path to the client certificate's private key file for mTLS authentication. This option is only used when `USE_TLS_AUTH` is set to `true`.
 
 ### `BOUNCING_ON_TYPE`
 

--- a/crowdsec-docs/unversioned/bouncers/nginx.mdx
+++ b/crowdsec-docs/unversioned/bouncers/nginx.mdx
@@ -32,6 +32,7 @@ import RemediationSupportBadges from '@site/src/components/remediation-support-b
   Mode
   Appsec
   Metrics
+  MTLS
 />
 
 A lua Remediation Component for nginx.
@@ -184,6 +185,11 @@ SECRET_KEY=
 SITE_KEY=
 CAPTCHA_TEMPLATE_PATH=/var/lib/crowdsec/lua/templates/captcha.html
 CAPTCHA_EXPIRATION=3600
+
+# mTLS Configuration
+USE_TLS_AUTH=false
+TLS_CLIENT_CERT=
+TLS_CLIENT_KEY=
 
 ## Application Security Component Configuration
 APPSEC_URL=
@@ -377,6 +383,36 @@ API_URL=http://<ip>:<port>
 ```
 
 CrowdSec local API URL.
+
+### `USE_TLS_AUTH`
+
+> boolean
+
+```bash
+USE_TLS_AUTH=false  # default
+```
+
+Enable mutual TLS (mTLS) authentication for secure communication with CrowdSec Local API. When enabled, the bouncer will use client certificates for authentication instead of API keys.
+
+### `TLS_CLIENT_CERT`
+
+> string (path to file)
+
+```bash
+TLS_CLIENT_CERT=<path_to_cert>
+```
+
+Path to the client certificate file for mTLS authentication. This option is only used when `USE_TLS_AUTH` is set to `true`.
+
+### `TLS_CLIENT_KEY`
+
+> string (path to file)
+
+```bash
+TLS_CLIENT_KEY=<path_to_key>
+```
+
+Path to the client certificate's private key file for mTLS authentication. This option is only used when `USE_TLS_AUTH` is set to `true`.
 
 ### `BOUNCING_ON_TYPE`
 > all | ban | captcha

--- a/crowdsec-docs/unversioned/bouncers/openresty.mdx
+++ b/crowdsec-docs/unversioned/bouncers/openresty.mdx
@@ -26,6 +26,7 @@ import RemediationSupportBadges from '@site/src/components/remediation-support-b
   Mode
   Appsec
   Metrics
+  MTLS
 />
 
 A lua Remediation Component for OpenResty.
@@ -163,6 +164,10 @@ SITE_KEY=
 CAPTCHA_TEMPLATE_PATH=/var/lib/crowdsec/lua/templates/captcha.html
 CAPTCHA_EXPIRATION=3600
 
+# mTLS Configuration
+USE_TLS_AUTH=false
+TLS_CLIENT_CERT=
+TLS_CLIENT_KEY=
 
 ## Application Security Component Configuration
 APPSEC_URL=
@@ -366,6 +371,36 @@ API_URL=http://<ip>:<port>
 ```
 
 CrowdSec local API URL.
+
+### `USE_TLS_AUTH`
+
+> boolean
+
+```bash
+USE_TLS_AUTH=false  # default
+```
+
+Enable mutual TLS (mTLS) authentication for secure communication with CrowdSec Local API. When enabled, the bouncer will use client certificates for authentication instead of API keys.
+
+### `TLS_CLIENT_CERT`
+
+> string (path to file)
+
+```bash
+TLS_CLIENT_CERT=<path_to_cert>
+```
+
+Path to the client certificate file for mTLS authentication. This option is only used when `USE_TLS_AUTH` is set to `true`.
+
+### `TLS_CLIENT_KEY`
+
+> string (path to file)
+
+```bash
+TLS_CLIENT_KEY=<path_to_key>
+```
+
+Path to the client certificate's private key file for mTLS authentication. This option is only used when `USE_TLS_AUTH` is set to `true`.
 
 ### `BOUNCING_ON_TYPE`
 > all | ban | captcha


### PR DESCRIPTION
Since the lua-cs-bouncer is now mTLS compatible, the downstream bouncers should now have mTLS capabilities:
- https://github.com/crowdsecurity/lua-cs-bouncer/pull/126

The bump on the lib has been merged for the OpenResty bouncer, but is not officially bumped, only taged:
https://github.com/crowdsecurity/cs-openresty-bouncer/pull/73

But I'm not sure that the nginx and ingress-nginx has been update to use the last version of the lua-cs-bouncer.

Anyway, i'll update the PR if they are not up to date.