### PR TITLE
docker: link to github readme instead of docker hub to avoid truncation issues

### DIFF
--- a/crowdsec-docs/unversioned/getting_started/installation/docker.mdx
+++ b/crowdsec-docs/unversioned/getting_started/installation/docker.mdx
@@ -110,7 +110,7 @@ depends_on:
 
 ## Environment variables
 
-You can find a full list of available environment variables on our [Docker Hub image page](https://hub.docker.com/r/crowdsecurity/crowdsec).
+You can find a full list of available environment variables in the [Docker image readme](https://github.com/crowdsecurity/crowdsec/blob/master/build/docker/README.md).
 
 Here are the most common environment variables for customizing CrowdSec in Docker:
 


### PR DESCRIPTION
Fixes #1085 