### PR TITLE
Links to APIs in header menu

### DIFF
--- a/crowdsec-docs/docusaurus.config.ts
+++ b/crowdsec-docs/docusaurus.config.ts
@@ -87,7 +87,6 @@ const NAVBAR_ITEMS: NavbarItem[] = [
 		position: "left",
 		label: "Blocklists",
 	},
-	{ to: "/u/cti_api/intro", position: "left", label: "IP Reputation & CTI" },
 	{ to: "/u/console/intro", position: "left", label: "Console" },
 	{
 		type: "html",
@@ -95,9 +94,11 @@ const NAVBAR_ITEMS: NavbarItem[] = [
 		position: "left",
 	},
 	{
-		label: "Resources",
+		label: "APIs & Resources",
 		position: "left",
 		items: [
+			{ to: "/u/cti_api/api_introduction", label: "CTI API" },
+			{ to: "/u/console/service_api/getting_started", label: "Service API" },
 			{
 				to: "/u/user_guides/intro",
 				label: "Guides",


### PR DESCRIPTION
First step towards making APIs more visible
* Adding them in Ressource menu
* Renaming menu APIs & Resources

<img width="2822" height="1014" alt="image" src="https://github.com/user-attachments/assets/26e9844b-a42f-4f42-9a3f-20325382d734" />
