### PR TITLE
document new datasource options for 1.8.0

### DIFF
--- a/crowdsec-docs/docs/log_processor/data_sources/appsec.md
+++ b/crowdsec-docs/docs/log_processor/data_sources/appsec.md
@@ -40,6 +40,8 @@ Defaults to `/`.
 
 The list of appsec-configs to use (as seen in `cscli appsec-configs list`).
 
+An entry can also be a glob pattern (`*` and `?`), which is expanded to all the *installed* appsec-configs matching it, for example `crowdsecurity/appsec-bot-challenge-exclude-*`. A pattern matching no installed appsec-config is an error.
+
 ### `appsec_config`
 
 **Deprecated**, use [`appsec_configs`](#appsec_configs)
@@ -56,6 +58,13 @@ Number of routines to use to process the requests. Defaults to 1.
 
 How long to cache the auth token for. Accepts value supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
 Defaults to 1m.
+
+### `auth_timeout`
+
+How long to wait for the local API to validate the API key of a remediation component. Accepts value supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
+Set to `0` to disable the timeout.
+Increase it if your local API is not on the same machine or is a few network hops away.
+Defaults to 200ms.
 
 ### `body_read_timeout`
 

--- a/crowdsec-docs/docs/log_processor/data_sources/http.md
+++ b/crowdsec-docs/docs/log_processor/data_sources/http.md
@@ -206,9 +206,9 @@ Optional.
 
 ### `max_body_size`
 
-The maximum body size to accept.
+The maximum body size to accept, in bytes, measured after decompression for compressed requests. Requests announcing or sending a bigger body are rejected with a `413` status code.
 
-Optional.
+Optional, defaults to `10485760` (10MB).
 
 ### `timeout`
 

--- a/crowdsec-docs/docs/log_processor/data_sources/kubernetes_audit.md
+++ b/crowdsec-docs/docs/log_processor/data_sources/kubernetes_audit.md
@@ -38,6 +38,12 @@ The path on which the datasource will accept requests from kubernetes.
 
 Mandatory.
 
+### `max_body_size`
+
+The maximum size, in bytes, of a request body. Requests announcing or sending a bigger body are rejected with a `413` status code.
+
+Optional, defaults to `10485760` (10MB).
+
 ### `source`
 
 Must be `k8s-audit`


### PR DESCRIPTION
Documents the datasource options added/changed in crowdsec 1.8.0:

- appsec: `auth_timeout` (crowdsecurity/crowdsec#4585), default 200ms, `0` disables
- appsec: `appsec_configs` entries now accept glob patterns, expanded against the installed appsec-configs
- k8s-audit: `max_body_size` (crowdsecurity/crowdsec#4630), default 10MB, `413` on oversize
- http: `max_body_size` now defaults to 10MB and is enforced after decompression (crowdsecurity/crowdsec#4616)

🤖 Generated with [Claude Code](https://claude.com/claude-code)