### PR TITLE
Fix typo in nginx.mdx

### DIFF
--- a/crowdsec-docs/unversioned/bouncers/nginx.mdx
+++ b/crowdsec-docs/unversioned/bouncers/nginx.mdx
@@ -731,7 +731,7 @@ If set to `true`, the request will be blocked directly by nginx.
 Nginx variables can be used to adapt behaviour and or more flexible configurations:
 
 - `ngx.var.crowdsec_disable_bouncer`: set to 1, it will disable the bouncer
-- `ngx.var.crowdsec_enable_bouncer`: set to 1, it will disable the bouncer
+- `ngx.var.crowdsec_enable_bouncer`: set to 1, it will enable the bouncer
 - `ngx.var.crowdsec_enable_appsec`: set to 1, it will enable the appsec even if it's disabled by configuration or if bouncer is disabled
 - `ngx.var.crowdsec_disable_appsec`: set to 1, it will disable the appsec
 - `ngx.var.crowdsec_always_send_to_appsec`: set 1, it will always send the request to appsec, even if a decision already exist for the ip requesting


### PR DESCRIPTION
This should be `enable`, not `disable`.